### PR TITLE
Move from using `Protocol` to abstract base class instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv*
 .vscode/
 
 dist/
+archive/

--- a/ditto/_unittest.py
+++ b/ditto/_unittest.py
@@ -3,7 +3,7 @@ import inspect
 from typing import ClassVar
 from pathlib import Path
 
-from ditto.snapshot import Snapshot
+from ditto import Snapshot
 
 
 def _calling_test_path() -> Path:

--- a/ditto/io/__init__.py
+++ b/ditto/io/__init__.py
@@ -1,37 +1,36 @@
-from ditto.io.protocol import SnapshotIO
-from ditto.io._yaml import YamlIO
-from ditto.io._json import JsonIO
-from ditto.io._pickle import PickleIO
-from ditto.io._pandas_parquet import PandasParquetIO
+from ditto.io._protocol import Base
+from ditto.io._yaml import Yaml
+from ditto.io._json import Json
+from ditto.io._pickle import Pickle
+from ditto.io._pandas_parquet import PandasParquet
 
 
 __all__ = [
-    "SnapshotIO",
-    "YamlIO",
-    "JsonIO",
-    "PickleIO",
-    "PandasParquetIO",
+    "Base" "Yaml",
+    "Json",
+    "Pickle",
+    "PandasParquet",
     "register",
     "get",
     "default",
 ]
 
 
-_NAME_IO_MAP: dict[str, type[SnapshotIO]] = {
-    "pkl": PickleIO,
-    "json": JsonIO,
-    "yaml": YamlIO,
-    "pandas_parquet": PandasParquetIO,
+_NAME_IO_MAP: dict[str, type[Base]] = {
+    "pkl": Pickle,
+    "json": Json,
+    "yaml": Yaml,
+    "pandas_parquet": PandasParquet,
 }
 
 
-def register(name: str, io: type[SnapshotIO]) -> None:
+def register(name: str, io: type[Base]) -> None:
     _NAME_IO_MAP[name] = io
 
 
-def get(name: str, default: SnapshotIO = PickleIO) -> SnapshotIO:
+def get(name: str, default: type[Base] = Pickle) -> type[Base]:
     return _NAME_IO_MAP.get(name, default)
 
 
-def default() -> type[SnapshotIO]:
-    return PickleIO
+def default() -> type[Base]:
+    return Pickle

--- a/ditto/io/_json.py
+++ b/ditto/io/_json.py
@@ -3,8 +3,10 @@ from typing import ClassVar, Any
 
 import json
 
+from ditto.io._protocol import Base
 
-class JsonIO:
+
+class Json(Base):
     extension: ClassVar[str] = "json"
 
     @staticmethod

--- a/ditto/io/_pandas_parquet.py
+++ b/ditto/io/_pandas_parquet.py
@@ -3,10 +3,10 @@ from typing import ClassVar
 
 import pandas as pd
 
-from ditto.io.protocol import SnapshotIO
+from ditto.io._protocol import Base
 
 
-class PandasParquetIO(SnapshotIO):
+class PandasParquet(Base):
     extension: ClassVar[str] = "parquet"
 
     @staticmethod

--- a/ditto/io/_pickle.py
+++ b/ditto/io/_pickle.py
@@ -3,10 +3,10 @@ from typing import ClassVar, Any
 
 import pickle
 
-from ditto.io import SnapshotIO
+from ditto.io._protocol import Base
 
 
-class PickleIO(SnapshotIO):
+class Pickle(Base):
     extension: ClassVar[str] = "pkl"
 
     @staticmethod

--- a/ditto/io/_protocol.py
+++ b/ditto/io/_protocol.py
@@ -1,13 +1,15 @@
 from pathlib import Path
-from typing import ClassVar, Any, Protocol
+from typing import ClassVar, Any
+from abc import ABCMeta, abstractmethod
 
 
-# TODO: maybe use abstract base class instead
-class SnapshotIO(Protocol):
+class Base(metaclass=ABCMeta):
     extension: ClassVar[str]
 
     @staticmethod
+    @abstractmethod
     def save(data: Any, filepath: Path) -> None: ...
 
     @staticmethod
+    @abstractmethod
     def load(filepath: Path) -> Any: ...

--- a/ditto/io/_yaml.py
+++ b/ditto/io/_yaml.py
@@ -3,8 +3,10 @@ from typing import ClassVar, Any
 
 import yaml
 
+from ditto.io._protocol import Base
 
-class YamlIO:
+
+class Yaml(Base):
     extension: ClassVar[str] = "yaml"
 
     @staticmethod

--- a/ditto/plugin.py
+++ b/ditto/plugin.py
@@ -1,8 +1,6 @@
-from typing import Any
-
 import pytest
 
-from ditto.snapshot import Snapshot
+from ditto import Snapshot
 from ditto import io
 
 
@@ -22,10 +20,7 @@ def snapshot(request) -> Snapshot:
 
     io_name = io_name if io_name is not None else "pkl"
 
-    # TODO: do i like this?
-    # if io_name is None:
-    #     pytest.fail("'record' is a required mark when using the 'snapshot' fixture.")
-
+    # TODO: parameterise the output path
     path = request.path.parent / ".ditto"
     path.mkdir(exist_ok=True)
 
@@ -37,7 +32,7 @@ def snapshot(request) -> Snapshot:
         path=path,
         name=identifier,
         # record=True,
-        io=io.get(io_name, default=io.PickleIO),
+        io=io.get(io_name, default=io.Pickle),
     )
 
 

--- a/ditto/snapshot.py
+++ b/ditto/snapshot.py
@@ -14,7 +14,7 @@ class Snapshot:
         path: Path,
         name: str,
         record: bool = False,
-        io: io.SnapshotIO = io.PickleIO,
+        io: io.Base = io.Pickle,
         identifier: str | None = None,
     ) -> None:
         self.path = path


### PR DESCRIPTION
Extra implementation strictness from `abc` seemed more useful at this point. The benefits of using a `Protocol` seemed small.