### PR TITLE
:adhesive_bandage: don't inherit protocol in IO subclasses

### DIFF
--- a/src/ditto/io/_json.py
+++ b/src/ditto/io/_json.py
@@ -3,10 +3,8 @@ from typing import ClassVar, Any
 
 import json
 
-from ditto.io._protocol import Base
 
-
-class Json(Base):
+class Json:
     extension: ClassVar[str] = "json"
 
     @staticmethod

--- a/src/ditto/io/_pickle.py
+++ b/src/ditto/io/_pickle.py
@@ -3,10 +3,8 @@ from typing import ClassVar, Any
 
 import pickle
 
-from ditto.io._protocol import Base
 
-
-class Pickle(Base):
+class Pickle:
     extension: ClassVar[str] = "pkl"
 
     @staticmethod

--- a/src/ditto/io/_yaml.py
+++ b/src/ditto/io/_yaml.py
@@ -3,10 +3,8 @@ from typing import ClassVar, Any
 
 import yaml
 
-from ditto.io._protocol import Base
 
-
-class Yaml(Base):
+class Yaml:
     extension: ClassVar[str] = "yaml"
 
     @staticmethod


### PR DESCRIPTION
Can't remember why I did this, need to remove.