### PR TITLE
README updates for `pytest-ditto-pyarrow`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,21 @@ specified per test by using `ditto` marks - customised `pytest` mark decorators.
 
 The default persistence types are: `pickle`, `yaml` and `json`; however additional
 plugins can be installed as per below:
-- pandas via `pytest-ditto-pandas`
+- `pandas` via `pytest-ditto-pandas`
+    - `@ditto.pandas.parquet`
+    - `@ditto.pandas.json`
+    - `@ditto.pandas.csv`
+- `pyarrow` via `pytest-ditto-pyarrow`
+    - `@ditto.pyarrow.parquet`
+    - `@ditto.pyarrow.feather`
+    - `@ditto.pyarrow.csv`
 
 
 ## Usage
 
 ### `pd.DataFrame`
+
+Install `pytest-ditto[pandas]` to make `pandas` IO types available.
 
 ```python
 import pandas as pd
@@ -61,10 +70,6 @@ def awesome_fn_to_test(df: pd.DataFrame):
     return df
 
 
-# The following test uses pandas.DataFrame.to_parquet to write the data snapshot to the
-# `.ditto` directory with filename:
-# `test_fn_with_parquet_dataframe_snapshot@ab_dataframe.pandas.parquet`.
-
 @ditto.pandas.parquet
 def test_fn_with_parquet_dataframe_snapshot(snapshot):
     input_data = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 9]})
@@ -72,13 +77,53 @@ def test_fn_with_parquet_dataframe_snapshot(snapshot):
     pd.testing.assert_frame_equal(result, snapshot(result, key="ab_dataframe"))
 
 
-# The following test uses pandas.DataFrame.to_json(orient="table") to write the data
-# snapshot to the `.ditto` directory with filename:
-# `test_fn_with_json_dataframe_snapshot@ab_dataframe.pandas.json`.
-
 @ditto.pandas.json
 def test_fn_with_json_dataframe_snapshot(snapshot):
     input_data = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 9]})
     result = awesome_fn_to_test(input_data)
     pd.testing.assert_frame_equal(result, snapshot(result, key="ab_dataframe"))
 ```
+
+For the above example the snapshot files would be found in the following locations:
+- `.ditto/test_fn_with_parquet_dataframe_snapshot@ab_dataframe.pandas.parquet`
+- `.ditto/test_fn_with_json_dataframe_snapshot@ab_dataframe.pandas.json`
+
+
+### `pyarrow.Table`
+
+Install `pytest-ditto[pyarrow]` to make `pyarrow` IO types available.
+
+```python
+import pyarrow as pa
+import pyarrow.compute as pc
+import ditto
+import pytest
+
+
+@pytest.fixture
+def table() -> pa.Table:
+    return pa.table(
+        [
+            [1, 2, 3, 4],
+            [4.5, 5.2, 6.8, 3.5],
+            [7, 8.5, None, None],
+            [True, False, True, True],
+            ["a", "b", "c", "x"],
+        ],
+        names=list("abcde"),
+    )
+
+
+def fn(x: pa.Table):
+    even_filter = (pc.bit_wise_and(pc.field("a"), pc.scalar(1)) == pc.scalar(0))
+    return x.filter(even_filter)
+
+
+@ditto.pyarrow.parquet
+def test_fn_with_pyarrow_parquet_snapshot(snapshot, table):
+    result = fn(table)
+    assert result.equals(snapshot(result, key="filtered"))
+```
+
+For the above example the snapshot files would be found in the following location:
+- `.ditto/test_fn_with_pyarrow_parquet_snapshot@filtered.pyarrow.parquet`

--- a/README.md
+++ b/README.md
@@ -43,14 +43,11 @@ specified per test by using `ditto` marks - customised `pytest` mark decorators.
 
 The default persistence types are: `pickle`, `yaml` and `json`; however additional
 plugins can be installed as per below:
-- `pandas` via `pytest-ditto-pandas`
-    - `@ditto.pandas.parquet`
-    - `@ditto.pandas.json`
-    - `@ditto.pandas.csv`
-- `pyarrow` via `pytest-ditto-pyarrow`
-    - `@ditto.pyarrow.parquet`
-    - `@ditto.pyarrow.feather`
-    - `@ditto.pyarrow.csv`
+
+| Types | Plugin | Marks |
+| --- | --- | --- |
+| `pandas` | `pytest-ditto-pandas` | <ul><li>`@ditto.pandas.parquet`</li><li>`@ditto.pandas.json`</li><li>`@ditto.pandas.csv`</li> |
+| `pyarrow` | `pytest-ditto-pyarrow` | <ul><li>`@ditto.pyarrow.parquet`</li><li>`@ditto.pyarrow.feather`</li><li>`@ditto.pyarrow.csv`</li> |
 
 
 ## Usage


### PR DESCRIPTION
Including additional documentation for `pyarrow.Table` objects via `pytest-ditto-pyarrow`.