### PR TITLE
Replace `ditto_backend` fixture with `target=` URI and backend registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ specified per test using `ditto` marks — customised `pytest` mark decorators.
 
 The built-in recorders are:
 
-| Mark | Recorder | File extension |
+| Mark | Recorder | Persisted suffix |
 | --- | --- | --- |
 | `@ditto.pickle` | pickle | `.pkl` |
 | `@ditto.yaml` | yaml | `.yaml` |
@@ -59,6 +59,11 @@ Additional recorders can be installed via plugins:
 | --- | --- | --- |
 | `pandas` | `pytest-ditto-pandas` | <ul><li>`@ditto.pandas.parquet`</li><li>`@ditto.pandas.json`</li><li>`@ditto.pandas.csv`</li> |
 | `pyarrow` | `pytest-ditto-pyarrow` | <ul><li>`@ditto.pyarrow.parquet`</li><li>`@ditto.pyarrow.feather`</li><li>`@ditto.pyarrow.csv`</li> |
+
+For plugin recorders, the persisted suffix is the recorder's canonical identifier,
+which may differ from both the mark alias and the recorder registry key. For
+example, `@ditto.pandas.csv` is an alias for `@ditto.record("pandas_csv")`, while
+the snapshot filename suffix is `.pandas.csv`.
 
 
 ## Usage
@@ -198,6 +203,119 @@ Once registered, the recorder is available by name via `@ditto.record("my_record
 Plugin marks (e.g. `@ditto.myplugin.myformat`) can also be registered via the
 `ditto_marks` entry point group.
 
+## Custom Backends
+
+By default, snapshots are stored in a `.ditto/` directory next to each test file.
+The storage target can be overridden at three levels, listed from highest to lowest
+priority:
+
+```
+mark target=  →  ditto_target ini  →  file://.ditto
+```
+
+### Per-test: `target=` in `@ditto.record()`
+
+Specify a URI directly in the mark to route a test's snapshots to a specific
+location. The format and storage location are controlled independently:
+`target=` sets where data is stored, and the recorder name sets how it is
+serialised.
+
+```python
+import ditto
+
+# local path relative to this test file
+@ditto.record("json", target="file://snapshots/group_a")
+def test_foo(snapshot): ...
+
+# S3 bucket (credentials from ditto_storage_options)
+@ditto.record("yaml", target="s3://my-bucket/ci-snapshots/")
+def test_bar(snapshot): ...
+
+# in-memory (ephemeral, no disk I/O)
+@ditto.record("pickle", target="memory://")
+def test_baz(snapshot): ...
+
+# registered non-fsspec backend
+@ditto.record("json", target="postgresql://db-host/mydb")
+def test_qux(snapshot): ...
+```
+
+`target=` accepts any URI whose scheme is a supported `fsspec` protocol or a
+scheme registered via the `ditto_backends` entry-point group.
+
+Relative `file://` paths resolve relative to the test file's directory, matching
+the default `.ditto/` behaviour.
+
+### Auth: `ditto_storage_options` fixture
+
+Credentials for remote backends belong in `conftest.py`, not in marks. Define a
+`ditto_storage_options` fixture returning a dict keyed by URI scheme:
+
+```python
+# conftest.py
+import os
+import pytest
+
+@pytest.fixture(scope="session")
+def ditto_storage_options():
+    return {
+        "s3": {"key": os.environ["AWS_KEY"], "secret": os.environ["AWS_SECRET"]},
+        "postgresql": {"password": os.environ["PGPASSWORD"]},
+        "redis": {"password": os.environ["REDIS_PASSWORD"]},
+    }
+```
+
+The values are passed as kwargs to `fsspec.core.url_to_fs` for fsspec schemes or
+to the registered backend factory for custom schemes. For PostgreSQL and DuckDB,
+credentials can also come from standard environment variables such as
+`PGPASSWORD` or `MOTHERDUCK_TOKEN`.
+
+### Project-wide: `ditto_target` ini
+
+Set a project-wide default URI in `pytest.ini` or `pyproject.toml`:
+
+```ini
+[pytest]
+ditto_target = s3://my-bucket/snapshots/
+```
+
+```toml
+[tool.pytest.ini_options]
+ditto_target = "s3://my-bucket/snapshots/"
+```
+
+Individual marks take precedence over this setting.
+
+### Custom backend plugins
+
+Non-fsspec backends such as Redis, PostgreSQL, or DuckDB are registered via the
+`ditto_backends` entry-point group. Each factory receives the full URI string plus
+any matching kwargs from `ditto_storage_options`:
+
+```python
+def create_my_backend(uri: str, **storage_options) -> MutableMapping[str, bytes]:
+    ...
+```
+
+```toml
+[project.entry-points.ditto_backends]
+myscheme = "my_package:create_my_backend"
+```
+
+Once registered, `target="myscheme://..."` works in any mark.
+
+### Migration from `ditto_backend`
+
+The accepted long-term model is `target=` plus backend registration and
+`ditto_storage_options`.
+
+If you previously used a `ditto_backend` fixture, migrate it by:
+
+1. registering a URI scheme under `ditto_backends`
+2. moving runtime auth and connection kwargs into `ditto_storage_options`
+3. selecting the backend with `target=` or `ditto_target`
+
+
 ## CLI
 
 The `ditto` command provides snapshot management tools independent of a test run.
@@ -284,3 +402,32 @@ ditto recorders
 ```
 
 <img width="39%" src="docs/img/ditto-recorders.png" alt="ditto recorders">
+
+### `ditto doctor`
+
+Runs health checks: verifies pytest is available and all registered plugins loaded
+successfully.
+
+```
+ditto doctor
+```
+
+### `ditto lint`
+
+Checks snapshot files for naming issues, unknown recorder formats, and empty files.
+Exits non-zero if any issues are found.
+
+```
+ditto lint
+ditto lint tests/ci/
+```
+
+### `ditto stats`
+
+Shows a per-directory snapshot usage breakdown (file count and total size per `.ditto/`
+directory). Complements `ditto status`, which shows session-level aggregates.
+
+```
+ditto stats
+ditto stats tests/ci/
+```

--- a/src/ditto/_unittest.py
+++ b/src/ditto/_unittest.py
@@ -23,11 +23,12 @@ class DittoTestCase(unittest.TestCase):
         # inspect.getfile(type(self)) returns the source file of the concrete test
         # class — deterministic regardless of how or where snapshot is accessed.
         test_file = Path(inspect.getfile(type(self)))
-        ditto_dir = test_file.parent / ".ditto"
+        ditto_dir = (test_file.parent / ".ditto").resolve()
+        abs_uri = f"file://{ditto_dir.as_posix()}"
 
         return Snapshot(
             module=test_file.stem,
             group_name=".".join(self.id().split(".")[-3:]),
-            backend=FsspecMapping(fsspec.filesystem("file"), ditto_dir.as_posix()),
-            path=ditto_dir,  # kept for deprecated .path access in existing tests
+            target=abs_uri,
+            _backend=FsspecMapping(fsspec.filesystem("file"), ditto_dir.as_posix()),
         )

--- a/src/ditto/_version.py
+++ b/src/ditto/_version.py
@@ -1,1 +1,1 @@
-__version__ = '1.1.0.post0.dev19+92b03f7'
+__version__ = '1.1.0.post0.dev38+abbf1af'

--- a/src/ditto/backends/_plugins.py
+++ b/src/ditto/backends/_plugins.py
@@ -8,11 +8,20 @@ from collections.abc import Callable, MutableMapping
 __all__ = ("BACKEND_REGISTRY", "load_backends")
 
 
-BACKEND_REGISTRY: dict[str, Callable[[], MutableMapping[str, bytes]]] = {}
+BACKEND_REGISTRY: dict[str, Callable[..., MutableMapping[str, bytes]]] = {}
 
 
 def load_backends() -> None:
-    """Load named backends from the 'ditto_backends' entry-point group."""
+    """Load URI-scheme backend factories from the `ditto_backends` entry-point group.
+
+    Notes
+    -----
+    Each entry point must resolve to a callable with the signature
+    `factory(uri: str, **storage_options) -> MutableMapping[str, bytes]`.
+
+    The entry point name is the URI scheme handled by that factory, for example
+    `redis`, `postgresql`, or `duckdb`.
+    """
     for ep in importlib.metadata.entry_points(group="ditto_backends"):
         try:
             BACKEND_REGISTRY[ep.name] = ep.load()

--- a/src/ditto/plugin.py
+++ b/src/ditto/plugin.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import MutableMapping
+from collections.abc import Hashable, MutableMapping
 from contextlib import AbstractContextManager, ExitStack
 from pathlib import Path
 from typing import Any, cast
@@ -23,6 +23,9 @@ from ditto.exceptions import AdditionalMarkError, DittoMarkHasNoIOType
 __all__ = ("snapshot",)
 
 
+TargetCacheKey = tuple[str, Hashable]
+
+
 # ---------------------------------------------------------------------------
 # Module-level session state — reset in pytest_sessionstart
 #
@@ -34,7 +37,7 @@ __all__ = ("snapshot",)
 
 _session_exit_stack: ExitStack = ExitStack()
 _entered_backends: dict[int, MutableMapping[str, bytes]] = {}
-_backend_cache: dict[str, MutableMapping[str, bytes]] = {}
+_backend_cache: dict[TargetCacheKey, MutableMapping[str, bytes]] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -107,23 +110,56 @@ def _get_storage_options(request: pytest.FixtureRequest) -> dict[str, dict]:
         return {}
 
 
+def _freeze_options(value: Any) -> Hashable:
+    """Return a stable hashable representation of nested storage options."""
+    if isinstance(value, dict):
+        items = [
+            (key, _freeze_options(item)) for key, item in value.items()
+        ]
+        return tuple(sorted(items, key=lambda item: repr(item[0])))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_options(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_freeze_options(item) for item in value)
+
+    hash(value)
+    return value
+
+
+def _canonicalize_uri(uri: str, test_dir: Path) -> str:
+    """Return the canonical URI used for backend construction and caching."""
+    parsed = urlparse(uri)
+    if parsed.scheme != "file":
+        return uri
+
+    path_str = parsed.netloc + parsed.path or ".ditto"
+    path = Path(path_str)
+    if not path.is_absolute():
+        path = (test_dir / path).resolve()
+    return f"file://{path.as_posix()}"
+
+
+def _cache_key(canonical_uri: str, opts: dict[str, Any]) -> TargetCacheKey | None:
+    """Return the per-session cache key for a resolved target, or None."""
+    try:
+        return canonical_uri, _freeze_options(opts)
+    except TypeError:
+        return None
+
+
 def _resolve_uri(
     uri: str,
     test_dir: Path,
     storage_options: dict[str, dict],
 ) -> tuple[MutableMapping[str, bytes], str]:
-    """Resolve a URI to (backend, absolute_uri).
+    """Resolve a URI to (backend, canonical_uri).
 
-    The returned absolute_uri is always fully-qualified (e.g.
-    `file:///home/user/project/tests/.ditto`), even when the input was a
-    relative `file://` URI. This value is stored as `Snapshot.target` and
-    drives key-format selection: `file://` → short keys, everything else →
-    namespaced keys.
+    canonical_uri is always fully-qualified for local `file://` targets and is
+    used both for backend construction and for per-session backend caching.
 
-    Resolution order
-    ----------------
+    **Resolution order** (first match wins)
     1. file://   — FsspecMapping on local filesystem; relative paths resolve
-                   relative to test_dir; result is cached in _backend_cache.
+                   relative to test_dir; result is cached by canonical URI + opts.
     2. BACKEND_REGISTRY scheme — factory(uri, **opts); for non-fsspec backends
                    such as Redis, PostgreSQL, DuckDB.
     3. fsspec    — fsspec.core.url_to_fs(uri, **opts); covers S3, GCS, Azure,
@@ -154,29 +190,35 @@ def _resolve_uri(
     parsed = urlparse(uri)
     scheme = parsed.scheme
     opts = storage_options.get(scheme, {})
+    canonical_uri = _canonicalize_uri(uri, test_dir)
+    cache_key = _cache_key(canonical_uri, opts)
+
+    if cache_key is not None and cache_key in _backend_cache:
+        return _backend_cache[cache_key], canonical_uri
+
+    canonical = urlparse(canonical_uri)
+    scheme = canonical.scheme
 
     if scheme == "file":
-        # urlparse("file://.ditto") → netloc=".ditto", path=""
-        # urlparse("file:///abs")   → netloc="",        path="/abs"
-        path_str = parsed.netloc + parsed.path or ".ditto"
-        p = Path(path_str)
-        if not p.is_absolute():
-            p = (test_dir / p).resolve()
-        abs_uri = f"file://{p.as_posix()}"
-        cache_key = p.as_posix()
-        if cache_key not in _backend_cache:
-            _backend_cache[cache_key] = FsspecMapping(
-                fsspec.filesystem("file"), p.as_posix()
-            )
-        return _backend_cache[cache_key], abs_uri
+        path = Path(canonical.netloc + canonical.path or ".ditto")
+        backend = FsspecMapping(fsspec.filesystem("file"), path.as_posix())
+        backend = _maybe_enter(backend)
+        if cache_key is not None:
+            _backend_cache[cache_key] = backend
+        return backend, canonical_uri
 
     if scheme in BACKEND_REGISTRY:
-        backend = BACKEND_REGISTRY[scheme](uri, **opts)
-        return _maybe_enter(backend), uri
+        backend = _maybe_enter(BACKEND_REGISTRY[scheme](canonical_uri, **opts))
+        if cache_key is not None:
+            _backend_cache[cache_key] = backend
+        return backend, canonical_uri
 
     if scheme in fsspec.available_protocols():
-        fs, root = fsspec.core.url_to_fs(uri, **opts)
-        return FsspecMapping(fs, root), uri
+        fs, root = fsspec.core.url_to_fs(canonical_uri, **opts)
+        backend = _maybe_enter(FsspecMapping(fs, root))
+        if cache_key is not None:
+            _backend_cache[cache_key] = backend
+        return backend, canonical_uri
 
     raise ValueError(
         f"Unknown backend scheme {scheme!r} in target URI {uri!r}. "
@@ -193,33 +235,24 @@ def _resolve_target(
 
     Implements the full precedence chain:
 
-        mark target=  →  ditto_backend fixture  →  ditto_target ini  →  file://.ditto
+        mark target=  →  ditto_target ini  →  file://.ditto
 
-    Returns (backend, absolute_uri). The absolute_uri is passed to Snapshot.target
-    and drives key-format selection.
-
-    The ditto_backend fixture is bypassed when target_uri is set. It remains
-    supported for backward compatibility and for backends that cannot be expressed
-    as a URI.
+    Returns (backend, canonical_uri). The canonical URI is passed to
+    `Snapshot.target` and drives key-format selection.
     """
+    fixturedefs = request._fixturemanager.getfixturedefs("ditto_backend", request.node)
+    if fixturedefs:
+        raise TypeError(
+            "ditto_backend is superseded by target=, backend registration, and "
+            "ditto_storage_options. Register a URI scheme under 'ditto_backends' "
+            "and configure runtime options via ditto_storage_options."
+        )
+
     test_dir = request.path.parent
     opts = _get_storage_options(request)
 
     if target_uri is not None:
         return _resolve_uri(target_uri, test_dir, opts)
-
-    try:
-        raw_backend = request.getfixturevalue("ditto_backend")
-        # ditto_backend provides an opaque MutableMapping without a URI.
-        # Use a sentinel URI so Snapshot.target is always set; the "backend"
-        # scheme is never "file", so namespaced keys are used for session-wide
-        # custom backends.
-        return _maybe_enter(raw_backend), "backend://"
-    except pytest.FixtureLookupError as exc:
-        if exc.argname != "ditto_backend":
-            # A dependency of ditto_backend failed to resolve — re-raise so the
-            # user sees the real error rather than silently falling back to local.
-            raise
 
     ini_uri = request.config.getini("ditto_target")
     return _resolve_uri(ini_uri, test_dir, opts)

--- a/src/ditto/plugin.py
+++ b/src/ditto/plugin.py
@@ -5,11 +5,13 @@ from collections.abc import MutableMapping
 from contextlib import AbstractContextManager, ExitStack
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlparse
 
 import pytest
 
 from ditto import Snapshot
 import fsspec
+import fsspec.core
 
 from ditto.backends import FsspecMapping
 from ditto.snapshot import session_tracker
@@ -86,6 +88,144 @@ def _resolve_recorder(marks: list) -> Recorder:
 
 
 # ---------------------------------------------------------------------------
+# URI resolution engine
+# ---------------------------------------------------------------------------
+
+
+def _parse_mark_target(marks: list) -> str | None:
+    """Return the target= URI from the record mark, or None if absent."""
+    if not marks:
+        return None
+    return marks[0].kwargs.get("target")
+
+
+def _get_storage_options(request: pytest.FixtureRequest) -> dict[str, dict]:
+    """Return per-scheme storage options from ditto_storage_options, or {}."""
+    try:
+        return request.getfixturevalue("ditto_storage_options")
+    except pytest.FixtureLookupError:
+        return {}
+
+
+def _resolve_uri(
+    uri: str,
+    test_dir: Path,
+    storage_options: dict[str, dict],
+) -> tuple[MutableMapping[str, bytes], str]:
+    """Resolve a URI to (backend, absolute_uri).
+
+    The returned absolute_uri is always fully-qualified (e.g.
+    `file:///home/user/project/tests/.ditto`), even when the input was a
+    relative `file://` URI. This value is stored as `Snapshot.target` and
+    drives key-format selection: `file://` → short keys, everything else →
+    namespaced keys.
+
+    Resolution order
+    ----------------
+    1. file://   — FsspecMapping on local filesystem; relative paths resolve
+                   relative to test_dir; result is cached in _backend_cache.
+    2. BACKEND_REGISTRY scheme — factory(uri, **opts); for non-fsspec backends
+                   such as Redis, PostgreSQL, DuckDB.
+    3. fsspec    — fsspec.core.url_to_fs(uri, **opts); covers S3, GCS, Azure,
+                   memory://, and all other fsspec protocols.
+    4. Unknown   — ValueError with an actionable install hint.
+
+    BACKEND_REGISTRY is checked before fsspec so plugins can override fsspec schemes.
+
+    Parameters
+    ----------
+    uri : str
+        A URI string, e.g. "file://.ditto", "s3://bucket/prefix/",
+        "redis://localhost:6379/0", "duckdb:///:memory:".
+    test_dir : Path
+        Directory of the test file. Used to resolve relative file:// paths.
+    storage_options : dict[str, dict]
+        Per-scheme kwargs from the ditto_storage_options fixture. The entry
+        keyed by the URI scheme is unpacked as kwargs into the factory or
+        fsspec.core.url_to_fs.
+
+    Raises
+    ------
+    ValueError
+        When the scheme is unrecognised by both BACKEND_REGISTRY and fsspec.
+    """
+    from ditto.backends import BACKEND_REGISTRY
+
+    parsed = urlparse(uri)
+    scheme = parsed.scheme
+    opts = storage_options.get(scheme, {})
+
+    if scheme == "file":
+        # urlparse("file://.ditto") → netloc=".ditto", path=""
+        # urlparse("file:///abs")   → netloc="",        path="/abs"
+        path_str = parsed.netloc + parsed.path or ".ditto"
+        p = Path(path_str)
+        if not p.is_absolute():
+            p = (test_dir / p).resolve()
+        abs_uri = f"file://{p.as_posix()}"
+        cache_key = p.as_posix()
+        if cache_key not in _backend_cache:
+            _backend_cache[cache_key] = FsspecMapping(
+                fsspec.filesystem("file"), p.as_posix()
+            )
+        return _backend_cache[cache_key], abs_uri
+
+    if scheme in BACKEND_REGISTRY:
+        backend = BACKEND_REGISTRY[scheme](uri, **opts)
+        return _maybe_enter(backend), uri
+
+    if scheme in fsspec.available_protocols():
+        fs, root = fsspec.core.url_to_fs(uri, **opts)
+        return FsspecMapping(fs, root), uri
+
+    raise ValueError(
+        f"Unknown backend scheme {scheme!r} in target URI {uri!r}. "
+        f"To add support: install an fsspec extension for {scheme!r}, or register a "
+        f"factory under the 'ditto_backends' entry-point group."
+    )
+
+
+def _resolve_target(
+    target_uri: str | None,
+    request: pytest.FixtureRequest,
+) -> tuple[MutableMapping[str, bytes], str]:
+    """Resolve the snapshot storage target for this test.
+
+    Implements the full precedence chain:
+
+        mark target=  →  ditto_backend fixture  →  ditto_target ini  →  file://.ditto
+
+    Returns (backend, absolute_uri). The absolute_uri is passed to Snapshot.target
+    and drives key-format selection.
+
+    The ditto_backend fixture is bypassed when target_uri is set. It remains
+    supported for backward compatibility and for backends that cannot be expressed
+    as a URI.
+    """
+    test_dir = request.path.parent
+    opts = _get_storage_options(request)
+
+    if target_uri is not None:
+        return _resolve_uri(target_uri, test_dir, opts)
+
+    try:
+        raw_backend = request.getfixturevalue("ditto_backend")
+        # ditto_backend provides an opaque MutableMapping without a URI.
+        # Use a sentinel URI so Snapshot.target is always set; the "backend"
+        # scheme is never "file", so namespaced keys are used for session-wide
+        # custom backends.
+        return _maybe_enter(raw_backend), "backend://"
+    except pytest.FixtureLookupError as exc:
+        if exc.argname != "ditto_backend":
+            # A dependency of ditto_backend failed to resolve — re-raise so the
+            # user sees the real error rather than silently falling back to local.
+            raise
+
+    ini_uri = request.config.getini("ditto_target")
+    return _resolve_uri(ini_uri, test_dir, opts)
+
+
+# ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
@@ -98,40 +238,17 @@ def snapshot(request: pytest.FixtureRequest) -> Snapshot:
     recorder = _resolve_recorder(marks)
     update = request.config.getoption("--ditto-update", default=False)
 
-    try:
-        raw_backend = request.getfixturevalue("ditto_backend")
-        backend = _maybe_enter(raw_backend)
-        return Snapshot(
-            module=module,
-            group_name=request.node.name,
-            recorder=recorder,
-            backend=backend,
-            update=update,
-        )
-    except pytest.FixtureLookupError as exc:
-        if exc.argname != "ditto_backend":
-            # A dependency of ditto_backend failed to resolve — re-raise so the
-            # user sees the real error rather than silently falling back to local.
-            raise exc from exc
-        local_path = request.path.parent / ".ditto"
-        # All tests in the same directory share one FsspecMapping instance so
-        # they share one _BackendRecord in session_tracker. Without this cache,
-        # each test gets a distinct object and Pass 1 of pytest_sessionfinish
-        # treats every other test's files as "not accessed", deleting them all.
-        cache_key = local_path.resolve().as_posix()
-        if cache_key not in _backend_cache:
-            _backend_cache[cache_key] = FsspecMapping(
-                fsspec.filesystem("file"), local_path.as_posix()
-            )
-        backend = _backend_cache[cache_key]
-        return Snapshot(
-            module=module,
-            group_name=request.node.name,
-            recorder=recorder,
-            backend=backend,
-            update=update,
-            path=local_path,  # kept for deprecated .path access; signals _filename_key
-        )
+    target_uri = _parse_mark_target(marks)
+    backend, abs_uri = _resolve_target(target_uri, request)
+
+    return Snapshot(
+        module=module,
+        group_name=request.node.name,
+        target=abs_uri,
+        _backend=backend,
+        recorder=recorder,
+        update=update,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +269,16 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store_true",
         default=False,
         help="After the session, delete snapshot files not accessed during this run.",
+    )
+    parser.addini(
+        "ditto_target",
+        help=(
+            "Default snapshot storage URI for all tests in this project. "
+            "Examples: 's3://my-bucket/ditto', 'file://.ditto'. "
+            "Relative file:// paths resolve relative to the test file. "
+            "Credentials come from the ditto_storage_options fixture."
+        ),
+        default="file://.ditto",
     )
 
 

--- a/src/ditto/recorders/_protocol.py
+++ b/src/ditto/recorders/_protocol.py
@@ -12,17 +12,27 @@ T = TypeVar("T")
 @dataclass(frozen=True)
 class Recorder(Generic[T]):
     """
-    Recorder: an extension string paired with save and load functions.
+    Recorder: a persisted identifier string paired with save and load functions.
 
     A `Recorder` specifies how snapshot data is written to and read from disk.
     The type parameter `T` constrains the data type this recorder operates on.
     Use `Recorder[Any]` for generic formats (pickle, yaml, json).
     Use a concrete type for format-specific recorders (e.g. `Recorder[pd.DataFrame]`).
 
+    Notes
+    -----
+    The field name `extension` is historical. Its current contract is broader than
+    a pure terminal file extension: it is the canonical persisted recorder
+    identifier appended to snapshot keys. Built-in recorders use short values such
+    as `pkl` and `json`; optional plugin recorders may use dotted identifiers such
+    as `pandas.parquet` or `pyarrow.csv`.
+
     Parameters
     ----------
     extension : str
-        File extension used for snapshot files (e.g. "pkl", "json").
+        Canonical persisted recorder identifier appended to snapshot names (e.g.
+        "pkl", "json", "pandas.parquet"). This value may contain dots and is
+        not guaranteed to match the mark alias or recorder registry key.
     save : Callable[[T, Path], None]
         Function that persists a value of type `T` to the given path.
     load : Callable[[Path], T]

--- a/src/ditto/snapshot.py
+++ b/src/ditto/snapshot.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from .exceptions import DuplicateSnapshotKeyError
 from .recorders import Recorder, default as _default_recorder
@@ -156,47 +155,33 @@ class Snapshot:
         Prefix used in snapshot keys, typically the test name.
     module : str
         Rootdir-relative test file stem (e.g. "tests/bar/test_api").
-        Used to namespace keys in shared backends.
+        Required for non-file:// backends to namespace keys across test files.
+        May be empty for file:// backends (module is implicit in directory path).
+    target : str
+        URI identifying the storage location. The scheme controls key format:
+        `file://` uses short `group@key.ext` keys (preserving on-disk layout);
+        all other schemes use fully-namespaced `module/group@key.ext` keys.
+        Always use absolute `file://` URIs (e.g. `file:///home/user/proj/tests/.ditto`).
+    _backend : MutableMapping[str, bytes]
+        Resolved storage backend. Conventionally private — set by the fixture via
+        `_resolve_target`. Use `target=` to communicate where data goes.
     recorder : Recorder
         Serialisation strategy. Defaults to pickle.
-    backend : MutableMapping[str, bytes]
-        Storage backend. Defaults to a local fsspec mapper derived from
-        `path` when `path` is provided (backward-compatible construction).
     update : bool
         When True, overwrite existing snapshots. Set by `--ditto-update`.
-    path : Path, optional
-        Deprecated. Provide `backend` directly instead. When set, a local
-        fsspec backend rooted at this path is created automatically and
-        `SnapshotKey.filename` (short keys) is used for storage.
     """
 
     group_name: str
-    module: str = ""
+    module: str
+    target: str
+    _backend: MutableMapping[str, bytes] = field(repr=False, compare=False, hash=False)
     recorder: Recorder = field(default_factory=_default_recorder)
-    backend: MutableMapping[str, bytes] | None = field(
-        default=None, compare=False, hash=False, repr=False
-    )
     update: bool = False
-    path: Path | None = field(default=None, compare=False, hash=False, repr=False)
 
     def __post_init__(self) -> None:
-        if self.path is not None and self.backend is None:
-            import fsspec
-
-            from .backends import FsspecMapping
-
-            object.__setattr__(
-                self,
-                "backend",
-                FsspecMapping(fsspec.filesystem("file"), self.path.as_posix()),
-            )
-        if self.backend is None:
+        if urlparse(self.target).scheme != "file" and not self.module:
             raise TypeError(
-                "Snapshot requires a storage target; provide backend= or path=."
-            )
-        if self.path is None and not self.module:
-            raise TypeError(
-                "Snapshot requires module= when using backend= directly. "
+                "Snapshot requires module= for non-file:// backends. "
                 "Pass the rootdir-relative test file stem, e.g. "
                 "module='tests/my_module/test_foo'."
             )
@@ -205,40 +190,15 @@ class Snapshot:
         return SnapshotKey(self.module, self.group_name, key, self.recorder.extension)
 
     def _key_of(self) -> Callable[[SnapshotKey], str]:
-        # Filesystem-local backends (constructed via path=) use the short filename
-        # key so existing .ditto/ layouts are preserved unchanged.
-        # All other backends use the fully-namespaced str form.
-        return _filename_key if self.path is not None else str
+        # file:// backends use the short filename key so existing .ditto/ layouts
+        # are preserved unchanged. All other backends use fully-namespaced keys.
+        return _filename_key if urlparse(self.target).scheme == "file" else str
 
     def _store(self) -> Any:
         from .backends import TransformMapping, _make_recorder_transform
 
-        if self.backend is None:
-            raise TypeError(
-                "Snapshot has no backend configured; "
-                "provide path= or backend= at construction."
-            )
-        return TransformMapping(mapping=self.backend) | _make_recorder_transform(
+        return TransformMapping(mapping=self._backend) | _make_recorder_transform(
             self.recorder
-        )
-
-    def filepath(self, key: str) -> Path:
-        """Deprecated. Will be removed in the next release.
-
-        Returns the filesystem path for a snapshot key. Only available for
-        filesystem backends (those constructed with `path=`).
-        """
-        warnings.warn(
-            "Snapshot.filepath() is deprecated and will be removed in the next release."
-            " Call snapshot(data, key=key) directly instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        sk = self._key(key)
-        if self.path is not None:
-            return self.path / sk.filename
-        raise TypeError(
-            "Snapshot.filepath() is only available for path-based snapshots."
         )
 
     def __call__(self, data: Any, key: str) -> Any:
@@ -289,12 +249,7 @@ def resolve_snapshot(snapshot: Snapshot, data: Any, key: str) -> Any:
     key_of = snapshot._key_of()
     storage_key = key_of(sk)
 
-    backend = snapshot.backend
-    if backend is None:
-        raise TypeError(
-            "Snapshot has no backend configured; "
-            "provide path= or backend= at construction."
-        )
+    backend = snapshot._backend
     used_key = (id(backend), storage_key)
     if used_key in session_tracker.used_keys:
         raise DuplicateSnapshotKeyError(key)

--- a/tests/ci/test_fixture.py
+++ b/tests/ci/test_fixture.py
@@ -58,18 +58,14 @@ def test_returns_each_value_when_called_with_different_keys(pytester) -> None:
     result.assert_outcomes(passed=1)
 
 
-def test_broken_ditto_backend_dependency_fails_loudly(pytester) -> None:
-    """A ditto_backend fixture whose own dependency is missing fails the test.
-
-    Regression: previously the FixtureLookupError was caught unconditionally,
-    silently falling back to LocalMapping and hiding the broken backend.
-    """
+def test_user_defined_ditto_backend_raises_migration_error(pytester) -> None:
+    """A user-defined ditto_backend fixture now fails with a migration error."""
     pytester.makepyfile("""
         import pytest
 
         @pytest.fixture
-        def ditto_backend(nonexistent_dep):
-            return nonexistent_dep
+        def ditto_backend():
+            return {}
 
         def test_inner(snapshot):
             snapshot("value", key="k")
@@ -78,6 +74,9 @@ def test_broken_ditto_backend_dependency_fails_loudly(pytester) -> None:
     result = pytester.runpytest()
 
     result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines([
+        "*ditto_backend is superseded by target=, backend registration, and ditto_storage_options*"
+    ])
 
 
 def test_prune_does_not_delete_snapshots_from_sibling_tests(pytester) -> None:
@@ -110,6 +109,31 @@ def test_prune_does_not_delete_snapshots_from_sibling_tests(pytester) -> None:
     result.stdout.no_fnmatch_line("*pruned*")
 
 
+def test_shared_memory_target_does_not_report_false_unused(pytester) -> None:
+    """Two tests sharing one memory target should not flag each other as unused."""
+    pytester.makepyfile(
+        test_alpha="""
+            import ditto
+
+            @ditto.record("json", target="memory://shared")
+            def test_alpha(snapshot):
+                assert snapshot({"value": "alpha"}, key="value") == {"value": "alpha"}
+        """,
+        test_beta="""
+            import ditto
+
+            @ditto.record("json", target="memory://shared")
+            def test_beta(snapshot):
+                assert snapshot({"value": "beta"}, key="value") == {"value": "beta"}
+        """,
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=2)
+    result.stderr.no_fnmatch_line("*│   unused*")
+
+
 def test_module_field_uses_forward_slashes(pytester) -> None:
     """The module field in SnapshotKey always uses forward slashes, even on Windows.
 
@@ -122,12 +146,14 @@ def test_module_field_uses_forward_slashes(pytester) -> None:
     """
     pytester.makeconftest("""
         import pytest
+        from ditto.backends import BACKEND_REGISTRY
 
         _backend = {}
 
-        @pytest.fixture
-        def ditto_backend():
+        def _factory(uri: str, **kwargs):
             return _backend
+
+        BACKEND_REGISTRY["test"] = _factory
 
         @pytest.fixture
         def stored_keys():
@@ -135,6 +161,8 @@ def test_module_field_uses_forward_slashes(pytester) -> None:
     """)
     subdir = pytester.mkdir("sub")
     subdir.joinpath("test_inner.py").write_text(
+        "import ditto\n\n"
+        "@ditto.record('pickle', target='test://shared')\n"
         "def test_inner(snapshot, stored_keys):\n"
         "    snapshot('v', key='k')\n"
         "    key = next(iter(stored_keys))\n"
@@ -150,6 +178,7 @@ def test_module_field_uses_forward_slashes(pytester) -> None:
 _ITER_RAISING_CONFTEST = """
     import pytest
     from collections.abc import MutableMapping, Iterator
+    from ditto.backends import BACKEND_REGISTRY
 
     class {cls}(MutableMapping):
         def __init__(self): self._d = {{}}
@@ -160,9 +189,10 @@ _ITER_RAISING_CONFTEST = """
         def __iter__(self) -> Iterator:
             raise {exc}("{msg}")
 
-    @pytest.fixture
-    def ditto_backend():
+    def _factory(uri: str, **kwargs):
         return {cls}()
+
+    BACKEND_REGISTRY["testiter"] = _factory
 """
 
 
@@ -174,7 +204,12 @@ def test_session_completes_when_backend_iter_raises_not_implemented(pytester) ->
             cls="NoIterBackend", exc="NotImplementedError", msg="no iteration"
         )
     )
-    pytester.makepyfile("def test_inner(snapshot): snapshot('v', key='k')")
+    pytester.makepyfile(
+        "import ditto\n\n"
+        "@ditto.record('pickle', target='testiter://shared')\n"
+        "def test_inner(snapshot):\n"
+        "    snapshot('v', key='k')\n"
+    )
 
     result = pytester.runpytest("-W", "always")
 
@@ -196,7 +231,12 @@ def test_session_completes_when_backend_iter_raises_ioerror(pytester) -> None:
             cls="BrokenIterBackend", exc="ConnectionError", msg="network gone"
         )
     )
-    pytester.makepyfile("def test_inner(snapshot): snapshot('v', key='k')")
+    pytester.makepyfile(
+        "import ditto\n\n"
+        "@ditto.record('pickle', target='testiter://shared')\n"
+        "def test_inner(snapshot):\n"
+        "    snapshot('v', key='k')\n"
+    )
 
     result = pytester.runpytest("-W", "always")
 

--- a/tests/ci/test_marks.py
+++ b/tests/ci/test_marks.py
@@ -8,9 +8,9 @@ import ditto
 
 def test_defaults_to_pickle_when_no_mark_is_applied(snapshot) -> None:
     """Without a record mark, the snapshot fixture uses pickle format."""
-    actual = snapshot.filepath("k")
+    actual = snapshot.recorder.extension
 
-    assert actual.suffix == ".pkl"
+    assert actual == "pkl"
 
 
 # --- Convenience marks ---
@@ -19,25 +19,25 @@ def test_defaults_to_pickle_when_no_mark_is_applied(snapshot) -> None:
 @ditto.pickle
 def test_uses_pickle_when_pickle_mark_is_applied(snapshot) -> None:
     """The @ditto.pickle convenience mark selects pickle format for the snapshot."""
-    actual = snapshot.filepath("k")
+    actual = snapshot.recorder.extension
 
-    assert actual.suffix == ".pkl"
+    assert actual == "pkl"
 
 
 @ditto.json
 def test_uses_json_when_json_mark_is_applied(snapshot) -> None:
     """The @ditto.json convenience mark selects json format for the snapshot."""
-    actual = snapshot.filepath("k")
+    actual = snapshot.recorder.extension
 
-    assert actual.suffix == ".json"
+    assert actual == "json"
 
 
 @ditto.yaml
 def test_uses_yaml_when_yaml_mark_is_applied(snapshot) -> None:
     """The @ditto.yaml convenience mark selects yaml format for the snapshot."""
-    actual = snapshot.filepath("k")
+    actual = snapshot.recorder.extension
 
-    assert actual.suffix == ".yaml"
+    assert actual == "yaml"
 
 
 # --- Raw record marks ---
@@ -46,25 +46,25 @@ def test_uses_yaml_when_yaml_mark_is_applied(snapshot) -> None:
 @ditto.record("pickle")
 def test_uses_pickle_when_raw_record_mark_specifies_pickle(snapshot) -> None:
     """The raw @ditto.record mark with 'pickle' selects pickle format."""
-    actual = snapshot.filepath("k")
+    actual = snapshot.recorder.extension
 
-    assert actual.suffix == ".pkl"
+    assert actual == "pkl"
 
 
 @ditto.record("json")
 def test_uses_json_when_raw_record_mark_specifies_json(snapshot) -> None:
     """The raw @ditto.record mark with 'json' selects json format."""
-    actual = snapshot.filepath("k")
+    actual = snapshot.recorder.extension
 
-    assert actual.suffix == ".json"
+    assert actual == "json"
 
 
 @ditto.record("yaml")
 def test_uses_yaml_when_raw_record_mark_specifies_yaml(snapshot) -> None:
     """The raw @ditto.record mark with 'yaml' selects yaml format."""
-    actual = snapshot.filepath("k")
+    actual = snapshot.recorder.extension
 
-    assert actual.suffix == ".yaml"
+    assert actual == "yaml"
 
 
 # --- Error cases ---

--- a/tests/ci/test_marks.py
+++ b/tests/ci/test_marks.py
@@ -87,3 +87,144 @@ def test_raises_when_multiple_record_marks_are_applied(snapshot) -> None:
 def test_raises_when_record_mark_specifies_unknown_recorder(snapshot) -> None:
     """Specifying an unregistered recorder name raises DittoMarkHasNoIOType."""
     pass
+
+
+# --- target resolution ---
+
+
+def test_target_relative_file_uri_resolves_to_nested_test_dir(pytester) -> None:
+    """A relative `file://` target resolves relative to the test file."""
+    subdir = pytester.mkdir("nested")
+    subdir.joinpath("test_inner.py").write_text(
+        "import ditto\n\n"
+        "@ditto.record('json', target='file://.custom')\n"
+        "def test_inner(snapshot):\n"
+        "    assert snapshot(42, key='x') == 42\n"
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+    assert (subdir / ".custom").is_dir()
+    assert list((subdir / ".custom").glob("*.json"))
+    assert not (pytester.path / ".custom").exists()
+
+
+def test_target_absolute_file_uri_uses_given_path(pytester, tmp_path) -> None:
+    """An absolute `file://` target stores snapshots at the requested path."""
+    target_dir = tmp_path / "snaps"
+    pytester.makepyfile(
+        f"""
+        import ditto
+
+        @ditto.record("json", target="file://{target_dir.as_posix()}")
+        def test_inner(snapshot):
+            assert snapshot(99, key="y") == 99
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+    assert target_dir.is_dir()
+    assert list(target_dir.glob("*.json"))
+
+
+def test_target_memory_uri_round_trips_without_creating_dot_ditto(pytester) -> None:
+    """A `memory://` target round-trips in process and does not create `.ditto`."""
+    pytester.makepyfile(
+        """
+        import ditto
+
+        @ditto.record("json", target="memory://")
+        def test_inner(snapshot):
+            assert snapshot({"a": 1}, key="z") == {"a": 1}
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+    assert not (pytester.path / ".ditto").exists()
+
+
+def test_mark_target_overrides_ditto_target_ini(pytester, tmp_path) -> None:
+    """A mark `target=` takes precedence over `ditto_target` in config."""
+    mark_dir = tmp_path / "mark-snaps"
+    ini_dir = tmp_path / "ini-snaps"
+    pytester.makeini(
+        f"""
+        [pytest]
+        ditto_target = file://{ini_dir.as_posix()}
+        """
+    )
+    pytester.makepyfile(
+        f"""
+        import ditto
+
+        @ditto.record("json", target="file://{mark_dir.as_posix()}")
+        def test_inner(snapshot):
+            assert snapshot(1, key="k") == 1
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+    assert mark_dir.is_dir()
+    assert not ini_dir.exists()
+
+
+def test_ditto_target_ini_applies_when_no_mark_is_present(pytester) -> None:
+    """Without a mark, `ditto_target` provides the project-wide default target."""
+    pytester.makeini(
+        """
+        [pytest]
+        ditto_target = file://.snapshots
+        """
+    )
+    subdir = pytester.mkdir("sub")
+    subdir.joinpath("test_inner.py").write_text(
+        "def test_inner(snapshot):\n"
+        "    assert snapshot(7, key='n') == 7\n"
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+    assert (subdir / ".snapshots").is_dir()
+    assert not (pytester.path / ".snapshots").exists()
+
+
+def test_default_target_falls_back_to_dot_ditto(pytester) -> None:
+    """Without a mark or config, the fixture falls back to `file://.ditto`."""
+    pytester.makepyfile(
+        """
+        def test_inner(snapshot):
+            assert snapshot(7, key="n") == 7
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+    assert (pytester.path / ".ditto").is_dir()
+    assert list((pytester.path / ".ditto").glob("*.pkl"))
+
+
+def test_unknown_target_scheme_raises_value_error(pytester) -> None:
+    """An unrecognised target scheme raises a helpful `ValueError`."""
+    pytester.makepyfile(
+        """
+        import ditto
+
+        @ditto.record("json", target="notascheme://something")
+        def test_inner(snapshot):
+            snapshot(1, key="k")
+        """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines(["*Unknown backend scheme*notascheme*"])

--- a/tests/ci/test_pandas_plugin.py
+++ b/tests/ci/test_pandas_plugin.py
@@ -29,8 +29,7 @@ def test_parquet_mark(snapshot) -> None:
     """The parquet mark selects the pandas_parquet recorder via the snapshot fixture."""
     data = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     snapshot(data, key="parquet")
-    assert snapshot.filepath("parquet").exists()
-    assert snapshot.filepath("parquet").suffix == ".parquet"
+    assert snapshot.recorder.extension == "parquet"
 
 
 @ditto.pandas.json
@@ -38,8 +37,7 @@ def test_json_mark(snapshot) -> None:
     """The json mark selects the pandas_json recorder via the snapshot fixture."""
     data = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     snapshot(data, key="json")
-    assert snapshot.filepath("json").exists()
-    assert snapshot.filepath("json").suffix == ".json"
+    assert snapshot.recorder.extension == "json"
 
 
 @ditto.pandas.csv
@@ -47,8 +45,7 @@ def test_csv_mark(snapshot) -> None:
     """The csv mark selects the pandas_csv recorder via the snapshot fixture."""
     data = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     snapshot(data, key="csv")
-    assert snapshot.filepath("csv").exists()
-    assert snapshot.filepath("csv").suffix == ".csv"
+    assert snapshot.recorder.extension == "csv"
 
 
 @pytest.mark.parametrize(

--- a/tests/ci/test_pandas_plugin.py
+++ b/tests/ci/test_pandas_plugin.py
@@ -29,7 +29,8 @@ def test_parquet_mark(snapshot) -> None:
     """The parquet mark selects the pandas_parquet recorder via the snapshot fixture."""
     data = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     snapshot(data, key="parquet")
-    assert snapshot.recorder.extension == "parquet"
+    assert snapshot.recorder is recorders.get("pandas_parquet")
+    assert snapshot.recorder.extension == "pandas.parquet"
 
 
 @ditto.pandas.json
@@ -37,7 +38,8 @@ def test_json_mark(snapshot) -> None:
     """The json mark selects the pandas_json recorder via the snapshot fixture."""
     data = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     snapshot(data, key="json")
-    assert snapshot.recorder.extension == "json"
+    assert snapshot.recorder is recorders.get("pandas_json")
+    assert snapshot.recorder.extension == "pandas.json"
 
 
 @ditto.pandas.csv
@@ -45,7 +47,8 @@ def test_csv_mark(snapshot) -> None:
     """The csv mark selects the pandas_csv recorder via the snapshot fixture."""
     data = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     snapshot(data, key="csv")
-    assert snapshot.recorder.extension == "csv"
+    assert snapshot.recorder is recorders.get("pandas_csv")
+    assert snapshot.recorder.extension == "pandas.csv"
 
 
 @pytest.mark.parametrize(

--- a/tests/ci/test_plugin_helpers.py
+++ b/tests/ci/test_plugin_helpers.py
@@ -1,16 +1,36 @@
 from collections.abc import Iterator, MutableMapping
 from contextlib import AbstractContextManager
+from pathlib import Path
 from unittest.mock import Mock
 
+import fsspec.core
 import pytest
 
+from ditto.backends import BACKEND_REGISTRY
 from ditto import recorders
 from ditto.exceptions import AdditionalMarkError, DittoMarkHasNoIOType
-from ditto.plugin import _maybe_enter, _resolve_recorder, _entered_backends
+from ditto.plugin import (
+    _backend_cache,
+    _entered_backends,
+    _freeze_options,
+    _maybe_enter,
+    _resolve_recorder,
+    _resolve_target,
+    _resolve_uri,
+)
 
 json_recorder = recorders.get("json")
 pickle_recorder = recorders.get("pickle")
 yaml_recorder = recorders.get("yaml")
+
+
+@pytest.fixture(autouse=True)
+def _clear_backend_state() -> Iterator[None]:
+    _entered_backends.clear()
+    _backend_cache.clear()
+    yield
+    _entered_backends.clear()
+    _backend_cache.clear()
 
 
 def _mark(*args):
@@ -101,6 +121,34 @@ class _WrappingBackend(AbstractContextManager, MutableMapping[str, bytes]):
         return len(self._data)
 
 
+class _CountingBackend(AbstractContextManager, MutableMapping[str, bytes]):
+    def __init__(self) -> None:
+        self._data: dict[str, bytes] = {}
+        self.enter_calls = 0
+
+    def __getitem__(self, key: str) -> bytes:
+        return self._data[key]
+
+    def __setitem__(self, key: str, value: bytes) -> None:
+        self._data[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __enter__(self) -> "_CountingBackend":
+        self.enter_calls += 1
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        pass
+
+
 def test_returns_entered_value_on_every_call_when_backend_is_context_manager() -> None:
     """The value returned by __enter__ is returned on every call, not the original backend."""
     _entered_backends.clear()
@@ -112,4 +160,145 @@ def test_returns_entered_value_on_every_call_when_backend_is_context_manager() -
     assert first is backend.wrapper
     assert second is backend.wrapper
     assert first is second
-    _entered_backends.clear()
+
+
+# --- URI resolution ---
+
+
+def test_freeze_options_handles_nested_mappings_sequences_and_sets() -> None:
+    actual = _freeze_options(
+        {"items": [1, {"flags": {"a", "b"}}], "token": "abc"}
+    )
+
+    assert actual == (
+        ("items", (1, (("flags", frozenset({"a", "b"})),))),
+        ("token", "abc"),
+    )
+
+
+def test_resolve_uri_caches_relative_file_target_by_canonical_path(tmp_path) -> None:
+    first_backend, first_uri = _resolve_uri("file://.ditto", tmp_path, {})
+    second_backend, second_uri = _resolve_uri("file://.ditto", tmp_path, {})
+
+    expected = f"file://{(tmp_path / '.ditto').resolve().as_posix()}"
+    assert first_uri == expected
+    assert second_uri == expected
+    assert first_backend is second_backend
+
+
+def test_resolve_uri_caches_registered_backend_by_uri_and_options(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    def factory(uri: str, **opts: str) -> MutableMapping[str, bytes]:
+        calls.append((uri, opts))
+        return {}
+
+    monkeypatch.setitem(BACKEND_REGISTRY, "demo", factory)
+
+    first_backend, first_uri = _resolve_uri(
+        "demo://shared", tmp_path, {"demo": {"token": "abc"}}
+    )
+    second_backend, second_uri = _resolve_uri(
+        "demo://shared", tmp_path, {"demo": {"token": "abc"}}
+    )
+
+    assert first_uri == "demo://shared"
+    assert second_uri == "demo://shared"
+    assert first_backend is second_backend
+    assert calls == [("demo://shared", {"token": "abc"})]
+
+
+def test_resolve_uri_separates_cache_entries_when_options_differ(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    def factory(uri: str, **opts: str) -> MutableMapping[str, bytes]:
+        calls.append((uri, opts))
+        return {}
+
+    monkeypatch.setitem(BACKEND_REGISTRY, "demo", factory)
+
+    first_backend, _ = _resolve_uri("demo://shared", tmp_path, {"demo": {"token": "a"}})
+    second_backend, _ = _resolve_uri("demo://shared", tmp_path, {"demo": {"token": "b"}})
+
+    assert first_backend is not second_backend
+    assert calls == [
+        ("demo://shared", {"token": "a"}),
+        ("demo://shared", {"token": "b"}),
+    ]
+
+
+def test_resolve_uri_enters_context_managed_backend_once_per_cache_entry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    constructed: list[_CountingBackend] = []
+
+    def factory(uri: str, **opts: str) -> MutableMapping[str, bytes]:
+        backend = _CountingBackend()
+        constructed.append(backend)
+        return backend
+
+    monkeypatch.setitem(BACKEND_REGISTRY, "ctx", factory)
+
+    first_backend, _ = _resolve_uri("ctx://shared", tmp_path, {})
+    second_backend, _ = _resolve_uri("ctx://shared", tmp_path, {})
+
+    assert len(constructed) == 1
+    assert constructed[0].enter_calls == 1
+    assert first_backend is second_backend
+
+
+def test_resolve_uri_raises_for_unknown_scheme(tmp_path) -> None:
+    """Unknown schemes raise a ValueError with an install hint."""
+    with pytest.raises(ValueError, match="Unknown backend scheme"):
+        _resolve_uri("notascheme://target", tmp_path, {})
+
+
+def test_resolve_uri_forwards_storage_options_to_fsspec(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Scheme-scoped storage options are forwarded to `fsspec.core.url_to_fs`."""
+    calls: list[tuple[str, dict[str, str]]] = []
+    fake_fs = Mock()
+
+    def fake_url_to_fs(uri: str, **opts: str) -> tuple[Mock, str]:
+        calls.append((uri, opts))
+        return fake_fs, "/shared-root"
+
+    monkeypatch.setattr(fsspec.core, "url_to_fs", fake_url_to_fs)
+
+    backend, uri = _resolve_uri(
+        "memory://shared", tmp_path, {"memory": {"token": "abc"}}
+    )
+
+    assert uri == "memory://shared"
+    assert getattr(backend, "root") == "/shared-root"
+    assert calls == [("memory://shared", {"token": "abc"})]
+
+
+def test_resolve_target_uses_ini_target_when_no_mark_is_present(tmp_path) -> None:
+    """Without a mark, the resolver falls back to `ditto_target`."""
+    request = Mock()
+    request._fixturemanager.getfixturedefs.return_value = None
+    request.node = object()
+    request.path = tmp_path / "test_example.py"
+    request.getfixturevalue.return_value = {}
+    request.config.getini.return_value = "file://.snapshots"
+
+    backend, uri = _resolve_target(None, request)
+
+    assert getattr(backend, "root") == (tmp_path / ".snapshots").resolve().as_posix()
+    assert uri == f"file://{(tmp_path / '.snapshots').resolve().as_posix()}"
+
+
+def test_resolve_target_raises_migration_error_for_user_defined_ditto_backend() -> None:
+    """A user-defined `ditto_backend` fixture triggers the migration error."""
+    request = Mock()
+    request._fixturemanager.getfixturedefs.return_value = [object()]
+    request.node = object()
+
+    with pytest.raises(TypeError, match="ditto_backend is superseded"):
+        _resolve_target(None, request)

--- a/tests/ci/test_pyarrow_plugin.py
+++ b/tests/ci/test_pyarrow_plugin.py
@@ -34,22 +34,18 @@ def test_pyarrow_marks_are_accessible() -> None:
 
 @ditto.pyarrow.parquet
 def test_parquet_mark(snapshot) -> None:
-    """The parquet mark selects the pyarrow_parquet recorder via the snapshot
-    fixture."""
+    """The parquet mark selects the pyarrow_parquet recorder via the snapshot fixture."""
     table = _make_table()
     snapshot(table, key="parquet")
-    assert snapshot.filepath("parquet").exists()
-    assert snapshot.filepath("parquet").suffix == ".parquet"
+    assert snapshot.recorder.extension == "parquet"
 
 
 @ditto.pyarrow.feather
 def test_feather_mark(snapshot) -> None:
-    """The feather mark selects the pyarrow_feather recorder via the snapshot
-    fixture."""
+    """The feather mark selects the pyarrow_feather recorder via the snapshot fixture."""
     table = _make_table()
     snapshot(table, key="feather")
-    assert snapshot.filepath("feather").exists()
-    assert snapshot.filepath("feather").suffix == ".feather"
+    assert snapshot.recorder.extension == "feather"
 
 
 @ditto.pyarrow.csv
@@ -57,8 +53,7 @@ def test_csv_mark(snapshot) -> None:
     """The csv mark selects the pyarrow_csv recorder via the snapshot fixture."""
     table = _make_table()
     snapshot(table, key="csv")
-    assert snapshot.filepath("csv").exists()
-    assert snapshot.filepath("csv").suffix == ".csv"
+    assert snapshot.recorder.extension == "csv"
 
 
 @pytest.mark.parametrize(

--- a/tests/ci/test_pyarrow_plugin.py
+++ b/tests/ci/test_pyarrow_plugin.py
@@ -37,7 +37,8 @@ def test_parquet_mark(snapshot) -> None:
     """The parquet mark selects the pyarrow_parquet recorder via the snapshot fixture."""
     table = _make_table()
     snapshot(table, key="parquet")
-    assert snapshot.recorder.extension == "parquet"
+    assert snapshot.recorder is recorders.get("pyarrow_parquet")
+    assert snapshot.recorder.extension == "pyarrow.parquet"
 
 
 @ditto.pyarrow.feather
@@ -45,7 +46,8 @@ def test_feather_mark(snapshot) -> None:
     """The feather mark selects the pyarrow_feather recorder via the snapshot fixture."""
     table = _make_table()
     snapshot(table, key="feather")
-    assert snapshot.recorder.extension == "feather"
+    assert snapshot.recorder is recorders.get("pyarrow_feather")
+    assert snapshot.recorder.extension == "pyarrow.feather"
 
 
 @ditto.pyarrow.csv
@@ -53,7 +55,8 @@ def test_csv_mark(snapshot) -> None:
     """The csv mark selects the pyarrow_csv recorder via the snapshot fixture."""
     table = _make_table()
     snapshot(table, key="csv")
-    assert snapshot.recorder.extension == "csv"
+    assert snapshot.recorder is recorders.get("pyarrow_csv")
+    assert snapshot.recorder.extension == "pyarrow.csv"
 
 
 @pytest.mark.parametrize(

--- a/tests/ci/test_redis_backend.py
+++ b/tests/ci/test_redis_backend.py
@@ -1,7 +1,7 @@
-"""Integration tests for a Redis-backed ditto_backend using fakeredis.
+"""Integration tests for a registered Redis backend using fakeredis.
 
-Demonstrates wiring a flat key-value store (Redis) as a ditto backend via
-PrefixedMapping + a thin MutableMapping adapter around the redis client.
+Demonstrates wiring a flat key-value store (Redis) as a target-resolved ditto
+backend via `redis://` plus a registered factory.
 """
 
 from __future__ import annotations
@@ -11,8 +11,9 @@ from contextlib import AbstractContextManager
 
 import fakeredis
 import pytest
+import ditto
 
-from ditto.backends import PrefixedMapping
+from ditto.backends import BACKEND_REGISTRY, PrefixedMapping
 
 
 # ---------------------------------------------------------------------------
@@ -74,14 +75,14 @@ def _redis_client() -> fakeredis.FakeRedis:
     return fakeredis.FakeRedis()
 
 
-@pytest.fixture(scope="session")
-def ditto_backend(_redis_client: fakeredis.FakeRedis) -> PrefixedMapping:
-    """Session-scoped Redis backend, matching real Redis usage across a suite.
+@pytest.fixture(scope="session", autouse=True)
+def _register_redis_backend(_redis_client: fakeredis.FakeRedis):
+    def create_redis_backend(uri: str, **kwargs) -> PrefixedMapping:
+        return PrefixedMapping(RedisMapping(_redis_client), prefix="ditto:")
 
-    PrefixedMapping scopes all keys under "ditto:" so ditto snapshots don't
-    collide with other tenants in a shared Redis instance.
-    """
-    return PrefixedMapping(RedisMapping(_redis_client), prefix="ditto:")
+    BACKEND_REGISTRY["redis"] = create_redis_backend
+    yield
+    BACKEND_REGISTRY.pop("redis", None)
 
 
 # ---------------------------------------------------------------------------
@@ -89,6 +90,7 @@ def ditto_backend(_redis_client: fakeredis.FakeRedis) -> PrefixedMapping:
 # ---------------------------------------------------------------------------
 
 
+@ditto.record("pickle", target="redis://localhost:6379/0")
 def test_snapshot_round_trips_value_through_redis(snapshot) -> None:
     """Snapshot stores and retrieves a value via the Redis backend."""
     result = snapshot({"answer": 42}, key="data")
@@ -96,11 +98,12 @@ def test_snapshot_round_trips_value_through_redis(snapshot) -> None:
     assert result == {"answer": 42}
 
 
+@ditto.record("pickle", target="redis://localhost:6379/0")
 def test_snapshot_keys_use_namespaced_format(_redis_client, snapshot) -> None:
     """Keys stored in Redis use the full module/group@key.ext namespaced form.
 
-    When a backend= is provided (not path=), SnapshotKey.__str__ is used,
-    producing slash-separated module paths for cross-file isolation.
+    Non-file targets use SnapshotKey.__str__ and therefore include the module
+    path for cross-file isolation.
     """
     snapshot(1, key="n")
 
@@ -111,6 +114,7 @@ def test_snapshot_keys_use_namespaced_format(_redis_client, snapshot) -> None:
     )
 
 
+@ditto.record("pickle", target="redis://localhost:6379/0")
 def test_snapshot_multiple_keys_in_one_test(snapshot) -> None:
     """Multiple snapshot calls with unique keys in one test all round-trip."""
     a = snapshot([1, 2, 3], key="list")
@@ -130,9 +134,9 @@ def test_unused_detection_reports_unaccessed_redis_keys(pytester) -> None:
     pytester.makeconftest("""
         from collections.abc import Iterator, MutableMapping
         from contextlib import AbstractContextManager
+        import ditto
         import fakeredis
-        import pytest
-        from ditto.backends import PrefixedMapping
+        from ditto.backends import BACKEND_REGISTRY, PrefixedMapping
 
         class RedisMapping(AbstractContextManager, MutableMapping):
             def __init__(self, client):
@@ -165,19 +169,27 @@ def test_unused_detection_reports_unaccessed_redis_keys(pytester) -> None:
 
         _shared_client = fakeredis.FakeRedis()
 
-        @pytest.fixture(scope="session")
-        def ditto_backend():
+        def create_redis_backend(uri: str, **kwargs):
             return PrefixedMapping(RedisMapping(_shared_client), prefix="ditto:")
+
+        BACKEND_REGISTRY["redis"] = create_redis_backend
     """)
     pytester.makepyfile(
         test_write="""
+            import ditto
+
+            @ditto.record("pickle", target="redis://localhost:6379/0")
             def test_write_alpha(snapshot):
                 snapshot("alpha-value", key="alpha")
 
+            @ditto.record("pickle", target="redis://localhost:6379/0")
             def test_write_beta(snapshot):
                 snapshot("beta-value", key="beta")
         """,
         test_read="""
+            import ditto
+
+            @ditto.record("pickle", target="redis://localhost:6379/0")
             def test_read_alpha_only(snapshot):
                 result = snapshot("alpha-value", key="alpha")
                 assert result == "alpha-value"

--- a/tests/ci/test_snapshot.py
+++ b/tests/ci/test_snapshot.py
@@ -11,6 +11,11 @@ from ditto.exceptions import DuplicateSnapshotKeyError
 from ditto.snapshot import load_snapshot, save_snapshot
 
 json_recorder = recorders.get("json")
+qualified_json_recorder = recorders.Recorder(
+    extension="plugin.json",
+    save=json_recorder.save,
+    load=json_recorder.load,
+)
 
 
 def _file_snapshot(path: Path, **kwargs) -> Snapshot:
@@ -120,6 +125,21 @@ def test_returns_stored_value_when_snapshot_already_exists(tmp_dir) -> None:
     actual = snapshot(["something-different"], key)
 
     assert actual == stored
+
+
+def test_file_backed_snapshot_preserves_dotted_recorder_identifier(tmp_dir) -> None:
+    """A dotted recorder identifier is preserved in the persisted snapshot name."""
+    snapshot = _file_snapshot(
+        tmp_dir,
+        group_name="group",
+        recorder=qualified_json_recorder,
+    )
+
+    actual = snapshot({"answer": 42}, "result")
+
+    assert actual == {"answer": 42}
+    assert (tmp_dir / "group@result.plugin.json").exists()
+    assert load_snapshot(snapshot, "result") == {"answer": 42}
 
 
 # --- update mode ---

--- a/tests/ci/test_snapshot.py
+++ b/tests/ci/test_snapshot.py
@@ -2,41 +2,35 @@ import json
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 
+import fsspec
 import pytest
 
 from ditto import Snapshot, recorders
+from ditto.backends import FsspecMapping
 from ditto.exceptions import DuplicateSnapshotKeyError
 from ditto.snapshot import load_snapshot, save_snapshot
 
 json_recorder = recorders.get("json")
 
 
+def _file_snapshot(path: Path, **kwargs) -> Snapshot:
+    """Create a file:// Snapshot backed by the given path."""
+    resolved = path.resolve()
+    return Snapshot(
+        target=f"file://{resolved.as_posix()}",
+        _backend=FsspecMapping(fsspec.filesystem("file"), resolved.as_posix()),
+        group_name=kwargs.pop("group_name", "group"),
+        module=kwargs.pop("module", ""),
+        **kwargs,
+    )
+
+
 # --- Snapshot dataclass ---
-
-
-def test_filepath_encodes_group_name_key_and_extension() -> None:
-    """The snapshot filepath encodes the group name, key, and recorder extension."""
-    key = "yek"
-    group_name = "puorg"
-    snapshot = Snapshot(path=Path(__file__).parent, group_name=group_name)
-
-    actual = snapshot.filepath(key)
-
-    assert actual == Path(__file__).parent / f"{group_name}@{key}.pkl"
-
-
-def test_filepath_reflects_recorder_extension() -> None:
-    """Filepath extension matches the extension of the configured recorder."""
-    snapshot = Snapshot(path=Path("/tests"), group_name="test", recorder=json_recorder)
-
-    actual = snapshot.filepath("key")
-
-    assert actual.suffix == ".json"
 
 
 def test_snapshot_is_immutable() -> None:
     """Snapshot rejects attribute assignment — frozen dataclass contract."""
-    snapshot = Snapshot(path=Path("/tests"), group_name="test")
+    snapshot = _file_snapshot(Path("/tests"), group_name="test")
 
     with pytest.raises(FrozenInstanceError):
         snapshot.group_name = "other"
@@ -45,20 +39,20 @@ def test_snapshot_is_immutable() -> None:
 # --- save_snapshot ---
 
 
-def test_writes_snapshot_to_disk(tmp_dir) -> None:
-    """save_snapshot writes the snapshot file to the configured path."""
+def test_writes_value_to_backend_on_save(tmp_dir) -> None:
+    """save_snapshot persists the value so it can be loaded back."""
     key = "langford-skolem-pair"
-    snapshot = Snapshot(path=tmp_dir, group_name="group")
+    snapshot = _file_snapshot(tmp_dir, group_name="group")
 
     save_snapshot(snapshot, 41312432, key)
 
-    assert snapshot.filepath(key).exists()
+    assert load_snapshot(snapshot, key) == 41312432
 
 
 def test_creates_output_directory_when_path_does_not_exist(tmp_dir) -> None:
     """save_snapshot creates the snapshot directory when it does not already exist."""
     path = tmp_dir / "nested" / "output"
-    snapshot = Snapshot(path=path, group_name="group")
+    snapshot = _file_snapshot(path, group_name="group")
 
     save_snapshot(snapshot, 42, "key")
 
@@ -70,7 +64,7 @@ def test_creates_output_directory_when_path_does_not_exist(tmp_dir) -> None:
 
 def test_raises_when_snapshot_file_is_absent(tmp_dir) -> None:
     """load_snapshot raises FileNotFoundError when the snapshot file is absent."""
-    snapshot = Snapshot(path=tmp_dir, group_name="group")
+    snapshot = _file_snapshot(tmp_dir, group_name="group")
 
     with pytest.raises(FileNotFoundError):
         load_snapshot(snapshot, "missing-key")
@@ -84,7 +78,7 @@ def test_returns_deserialised_stored_value(tmp_dir) -> None:
 
     with open(tmp_dir / f"{group_name}@{key}.json", "w") as f:
         json.dump(value, f)
-    snapshot = Snapshot(path=tmp_dir, group_name=group_name, recorder=json_recorder)
+    snapshot = _file_snapshot(tmp_dir, group_name=group_name, recorder=json_recorder)
 
     actual = load_snapshot(snapshot, key)
 
@@ -94,29 +88,19 @@ def test_returns_deserialised_stored_value(tmp_dir) -> None:
 # --- resolve_snapshot (via __call__) ---
 
 
-def test_saves_file_to_disk_on_first_call(tmp_dir) -> None:
-    """Calling snapshot when no file exists writes the value to disk."""
+def test_saves_value_to_backend_on_first_call(tmp_dir) -> None:
+    """Calling snapshot when no file exists writes the value and returns it."""
     key = "A001844"
-    snapshot = Snapshot(path=tmp_dir, group_name="OEIS")
+    snapshot = _file_snapshot(tmp_dir, group_name="OEIS")
     data = [1, 5, 13, 25, 41, 61, 85, 113, 145, 181, 221, 265, 313]
 
-    snapshot(data, key)
+    result = snapshot(data, key)
 
-    assert snapshot.filepath(key).exists()
-
-
-def test_returns_data_on_first_call(tmp_dir) -> None:
-    """Calling snapshot when no file exists returns the passed data."""
-    key = "A001844"
-    snapshot = Snapshot(path=tmp_dir, group_name="OEIS")
-    data = [1, 5, 13, 25, 41, 61, 85, 113, 145, 181, 221, 265, 313]
-
-    actual = snapshot(data, key)
-
-    assert actual == data
+    assert load_snapshot(snapshot, key) == data
+    assert result == data
 
 
-def test_returns_stored_value_when_file_already_exists(tmp_dir) -> None:
+def test_returns_stored_value_when_snapshot_already_exists(tmp_dir) -> None:
     """snapshot returns the stored value, not the argument, when the file exists."""
     key = "rainbow"
     group_name = "colours"
@@ -131,7 +115,7 @@ def test_returns_stored_value_when_file_already_exists(tmp_dir) -> None:
 
     with open(tmp_dir / f"{group_name}@{key}.json", "w") as f:
         json.dump(stored, f)
-    snapshot = Snapshot(path=tmp_dir, group_name=group_name, recorder=json_recorder)
+    snapshot = _file_snapshot(tmp_dir, group_name=group_name, recorder=json_recorder)
 
     actual = snapshot(["something-different"], key)
 
@@ -144,7 +128,7 @@ def test_returns_stored_value_when_file_already_exists(tmp_dir) -> None:
 def test_returns_new_value_when_update_is_true(tmp_dir) -> None:
     """When update=True, snapshot returns the new value rather than the stored one."""
     key = "result"
-    snapshot = Snapshot(path=tmp_dir, group_name="group", update=True)
+    snapshot = _file_snapshot(tmp_dir, group_name="group", update=True)
     save_snapshot(snapshot, "original", key)
 
     actual = snapshot("updated", key)
@@ -152,10 +136,10 @@ def test_returns_new_value_when_update_is_true(tmp_dir) -> None:
     assert actual == "updated"
 
 
-def test_overwrites_stored_file_when_update_is_true(tmp_dir) -> None:
+def test_overwrites_stored_value_when_update_is_true(tmp_dir) -> None:
     """When update=True, snapshot replaces the value on disk."""
     key = "result"
-    snapshot = Snapshot(path=tmp_dir, group_name="group", update=True)
+    snapshot = _file_snapshot(tmp_dir, group_name="group", update=True)
     save_snapshot(snapshot, "original", key)
 
     snapshot("updated", key)
@@ -168,7 +152,7 @@ def test_overwrites_stored_file_when_update_is_true(tmp_dir) -> None:
 
 def test_raises_when_key_is_reused_within_same_snapshot(tmp_dir) -> None:
     """Calling snapshot twice with the same key raises DuplicateSnapshotKeyError."""
-    snapshot = Snapshot(path=tmp_dir, group_name="group")
+    snapshot = _file_snapshot(tmp_dir, group_name="group")
     snapshot(42, "result")
 
     with pytest.raises(DuplicateSnapshotKeyError):
@@ -177,7 +161,7 @@ def test_raises_when_key_is_reused_within_same_snapshot(tmp_dir) -> None:
 
 def test_duplicate_key_error_names_the_offending_key(tmp_dir) -> None:
     """DuplicateSnapshotKeyError message identifies which key was reused."""
-    snapshot = Snapshot(path=tmp_dir, group_name="group")
+    snapshot = _file_snapshot(tmp_dir, group_name="group")
     snapshot(42, "result")
 
     with pytest.raises(DuplicateSnapshotKeyError, match="'result'"):
@@ -186,7 +170,7 @@ def test_duplicate_key_error_names_the_offending_key(tmp_dir) -> None:
 
 def test_does_not_raise_when_different_keys_are_used(tmp_dir) -> None:
     """snapshot accepts multiple calls within a test as long as each key is unique."""
-    snapshot = Snapshot(path=tmp_dir, group_name="group")
+    snapshot = _file_snapshot(tmp_dir, group_name="group")
 
     first = snapshot(1, "first")
     second = snapshot(2, "second")
@@ -195,27 +179,22 @@ def test_does_not_raise_when_different_keys_are_used(tmp_dir) -> None:
     assert second == 2
 
 
-def test_raises_when_filepath_called_on_backend_only_snapshot() -> None:
-    """filepath() raises TypeError when the snapshot has no path-based storage."""
-    backend: dict[str, bytes] = {}
-    snapshot = Snapshot(group_name="test", module="mod", backend=backend)
-
-    with pytest.raises(TypeError, match="path-based"):
-        snapshot.filepath("key")
+# --- construction validation ---
 
 
-def test_raises_at_construction_when_no_storage_target_is_given() -> None:
-    """Snapshot raises TypeError immediately when neither path= nor backend= is provided."""
-    with pytest.raises(TypeError, match="Snapshot requires a storage target"):
-        Snapshot(group_name="test")
-
-
-def test_raises_at_construction_when_backend_used_without_module() -> None:
-    """Snapshot raises TypeError when backend= is given without module=.
-
-    Without module=, _key_of() uses str(sk) which produces a leading-slash key
-    ("/group@key.ext"), causing a cryptic ValueError deep inside FsspecMapping.
-    The guard in __post_init__ catches this at construction time instead.
-    """
+def test_raises_at_construction_when_module_is_empty_for_non_file_scheme() -> None:
+    """Snapshot raises TypeError when a non-file:// target is given without module=."""
     with pytest.raises(TypeError, match="module="):
-        Snapshot(group_name="test", backend={})
+        Snapshot(
+            group_name="test",
+            module="",
+            target="memory://",
+            _backend={},
+        )
+
+
+def test_accepts_empty_module_for_file_scheme(tmp_dir) -> None:
+    """Snapshot allows module='' for file:// targets — module is implicit in path."""
+    snapshot = _file_snapshot(tmp_dir, group_name="test", module="")
+
+    assert snapshot.module == ""

--- a/tests/ci/test_snapshot_key.py
+++ b/tests/ci/test_snapshot_key.py
@@ -12,6 +12,18 @@ def test_filename_uses_short_form() -> None:
     assert sk.filename == "test_result@v.pkl"
 
 
+def test_filename_preserves_multi_dot_identifier() -> None:
+    """filename preserves a dotted persisted recorder identifier unchanged."""
+    sk = SnapshotKey(
+        module="tests/bar/test_api",
+        group_name="test_result",
+        key="v",
+        extension="pandas.parquet",
+    )
+
+    assert sk.filename == "test_result@v.pandas.parquet"
+
+
 def test_str_uses_namespaced_form() -> None:
     """str includes the module so remote backends can distinguish same-named tests
     across files."""

--- a/tests/ci/test_snapshot_properties.py
+++ b/tests/ci/test_snapshot_properties.py
@@ -1,15 +1,13 @@
-"""Property-based tests for Snapshot filepath construction and key-tracking
-invariants."""
+"""Property-based tests for Snapshot key-tracking invariants."""
 
 from __future__ import annotations
 
 import pytest
-from hypothesis import HealthCheck, given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
-from ditto import recorders
 from ditto.exceptions import DuplicateSnapshotKeyError
-from ditto.snapshot import Snapshot, session_tracker
+from ditto.snapshot import Snapshot, SnapshotKey, session_tracker
 
 # Keys safe for use as filesystem names on Linux: no path separators, null bytes,
 # or surrogate characters (surrogates cannot be encoded as UTF-8 filenames).
@@ -24,44 +22,16 @@ _safe_key = st.text(
     ),
 )
 
-_recorder_names = ["pickle", "json", "yaml"]
 
-# tmp_path is reused across examples — safe because filepath() is pure and the
-# snapshot tests reset session_tracker before each example. Suppress the check.
-_no_fixture_reset = settings(
-    suppress_health_check=[HealthCheck.function_scoped_fixture]
-)
-
-# ── Snapshot.filepath ─────────────────────────────────────────────────────────
-
-
-@_no_fixture_reset
-@given(
-    key=_safe_key,
-    recorder_name=st.sampled_from(_recorder_names),
-)
-def test_filepath_extension_always_matches_recorder_extension(
-    tmp_path, key: str, recorder_name: str
-) -> None:
-    """The filepath for any key always ends with the configured recorder's extension."""
-    recorder = recorders.get(recorder_name)
-    snapshot = Snapshot(path=tmp_path, group_name="test", recorder=recorder)
-
-    fp = snapshot.filepath(key)
-
-    assert fp.name.endswith(f".{recorder.extension}")
-
-
-@_no_fixture_reset
-@given(key=_safe_key)
-def test_filepath_parent_is_always_snapshot_path(tmp_path, key: str) -> None:
-    """The filepath for any simple key is a direct child of snapshot.path — no
-    subdirectories."""
-    snapshot = Snapshot(path=tmp_path, group_name="test")
-
-    fp = snapshot.filepath(key)
-
-    assert fp.parent == tmp_path
+def _memory_snapshot(**kwargs) -> Snapshot:
+    """Create a memory:// Snapshot backed by a plain dict for duplicate-key tests."""
+    return Snapshot(
+        target="memory://",
+        _backend={},
+        group_name=kwargs.pop("group_name", "test"),
+        module=kwargs.pop("module", "m"),
+        **kwargs,
+    )
 
 
 # ── Duplicate key detection ───────────────────────────────────────────────────
@@ -69,10 +39,9 @@ def test_filepath_parent_is_always_snapshot_path(tmp_path, key: str) -> None:
 
 @given(key=_safe_key)
 def test_duplicate_key_always_raises_on_second_call(key: str) -> None:
-    """Calling snapshot twice with the same key always raises
-    DuplicateSnapshotKeyError."""
+    """Calling snapshot twice with the same key always raises DuplicateSnapshotKeyError."""
     session_tracker.reset_keys()
-    snapshot = Snapshot(group_name="test", module="m", backend={})
+    snapshot = _memory_snapshot()
     snapshot(1, key)
 
     with pytest.raises(DuplicateSnapshotKeyError):
@@ -81,25 +50,21 @@ def test_duplicate_key_always_raises_on_second_call(key: str) -> None:
 
 @given(keys=st.lists(_safe_key, min_size=1, max_size=10, unique=True))
 def test_unique_keys_never_trigger_duplicate_error(keys: list[str]) -> None:
-    """Using a distinct key for each snapshot call never raises, regardless of how
-    many calls are made."""
+    """Using a distinct key for each snapshot call never raises, regardless of how many calls are made."""
     session_tracker.reset_keys()
-    snapshot = Snapshot(group_name="test", module="m", backend={})
+    snapshot = _memory_snapshot()
 
     for i, key in enumerate(keys):
         snapshot(i, key)
 
 
 def test_reset_keys_does_not_clear_session_level_created_list() -> None:
-    """reset_keys() must not clear `created` or `updated` — those are session-level
-    accumulators read by render_session_report at the end of the session.
+    """reset_keys() must not clear `created` or `updated` — those are session-level accumulators.
 
     Regression: reset_keys() previously cleared both lists, so any snapshots
     created by ordinary tests before a Hypothesis test ran were wiped from the
     report when the first Hypothesis example called reset_keys().
     """
-    from ditto.snapshot import SnapshotKey
-
     session_tracker.reset()
     sk = SnapshotKey(module="m", group_name="g", key="k", extension="pkl")
     session_tracker.created.append(sk)

--- a/tests/ci/test_unittest.py
+++ b/tests/ci/test_unittest.py
@@ -1,7 +1,13 @@
 import pickle
+from pathlib import Path
+from urllib.parse import urlparse
 
 import ditto
-from pathlib import Path
+
+
+def _ditto_dir(snapshot: ditto.Snapshot) -> Path:
+    """Derive the .ditto directory path from a file:// Snapshot target URI."""
+    return Path(urlparse(snapshot.target).path)
 
 
 class TestDittoTestCaseSnapshot(ditto.DittoTestCase):
@@ -12,11 +18,13 @@ class TestDittoTestCaseSnapshot(ditto.DittoTestCase):
 
         assert first is second
 
-    def test_snapshot_path_is_adjacent_to_test_file(self):
+    def test_target_is_adjacent_to_test_file(self):
         """Snapshot files are stored in a .ditto dir next to the test file."""
-        expected = Path(__file__).parent / ".ditto"
+        expected = (Path(__file__).parent / ".ditto").resolve()
 
-        assert self.snapshot.path == expected
+        actual = Path(urlparse(self.snapshot.target).path)
+
+        assert actual == expected
 
     def test_group_name_is_derived_from_test_id(self):
         """group_name is the last three dot-separated parts of the unittest test ID."""
@@ -26,7 +34,7 @@ class TestDittoTestCaseSnapshot(ditto.DittoTestCase):
 
     def test_returns_value_on_first_call(self):
         """On first call, snapshot returns the value that was passed to it."""
-        snapshot_file = self.snapshot.path / f"{self.snapshot.group_name}@v.pkl"
+        snapshot_file = _ditto_dir(self.snapshot) / f"{self.snapshot.group_name}@v.pkl"
         self.addCleanup(snapshot_file.unlink, missing_ok=True)
 
         actual = self.snapshot({"a": 1}, key="v")
@@ -35,7 +43,7 @@ class TestDittoTestCaseSnapshot(ditto.DittoTestCase):
 
     def test_creates_snapshot_file_on_first_call(self):
         """On first call, snapshot writes the value to disk."""
-        snapshot_file = self.snapshot.path / f"{self.snapshot.group_name}@w.pkl"
+        snapshot_file = _ditto_dir(self.snapshot) / f"{self.snapshot.group_name}@w.pkl"
         self.addCleanup(snapshot_file.unlink, missing_ok=True)
 
         self.snapshot({"a": 1}, key="w")
@@ -44,8 +52,9 @@ class TestDittoTestCaseSnapshot(ditto.DittoTestCase):
 
     def test_loads_stored_value_when_snapshot_file_already_exists(self):
         """snapshot returns the stored value when the snapshot file already exists."""
-        snapshot_file = self.snapshot.path / f"{self.snapshot.group_name}@v2.pkl"
-        snapshot_file.parent.mkdir(parents=True, exist_ok=True)
+        ditto_dir = _ditto_dir(self.snapshot)
+        snapshot_file = ditto_dir / f"{self.snapshot.group_name}@v2.pkl"
+        ditto_dir.mkdir(parents=True, exist_ok=True)
         snapshot_file.write_bytes(pickle.dumps({"b": 2}))
         self.addCleanup(snapshot_file.unlink, missing_ok=True)
 


### PR DESCRIPTION
## Summary

- Replaces `path=`/`backend=` mark arguments and the `ditto_backend` fixture with a unified `target=` URI parameter on `@ditto.record()`
- Tightens backend caching to key on `(canonical_uri, frozen_opts)` so different schemes and auth options get distinct entries; relative `file://` paths are canonicalised before caching or construction
- `ditto_backend` now raises `TypeError` with a migration hint pointing to `target=`, `ditto_backends` entry-point registration, and `ditto_storage_options`
- Adds `ditto_storage_options` fixture and `ditto_target` ini option for project-wide defaults
- Applies `_maybe_enter` consistently across all three resolution branches (file, registry, fsspec)
- Expands README with full backend configuration docs (`target=`, `ditto_storage_options`, `ditto_target`, custom backend plugins, migration guide)
- Updates all tests to register backends via `BACKEND_REGISTRY` rather than `ditto_backend` fixtures; adds integration tests for URI precedence, relative/absolute `file://` paths, `memory://` isolation, shared-target false-unused detection, and unknown-scheme error messaging

## Test plan

- [x] `pixi run pytest` passes on the branch
- [x] `test_target_relative_file_uri_resolves_to_nested_test_dir` — relative `file://` resolves to test file's directory
- [x] `test_target_absolute_file_uri_uses_given_path` — absolute `file://` stores at given path
- [x] `test_target_memory_uri_round_trips_without_creating_dot_ditto` — `memory://` leaves no `.ditto` on disk
- [x] `test_mark_target_overrides_ditto_target_ini` — mark `target=` wins over ini
- [x] `test_user_defined_ditto_backend_raises_migration_error` — `ditto_backend` fixture raises with helpful message
- [x] `test_shared_memory_target_does_not_report_false_unused` — shared target does not produce false unused warnings