### PR TITLE
CLI remote-backend introspection for list/status/stats/lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,20 @@ this repository does not ship installable backend plugins for those schemes.
 
 The `ditto` command provides snapshot management tools independent of a test run.
 
+### CLI and remote backends
+
+`ditto list`, `status`, `stats`, and `lint` work with remote and registered
+backends, not just local `file://` snapshots. To stay correct in the presence of
+per-test `record(target=...)` marks and fixture-defined profiles — which static
+config inspection cannot see — these commands always run an internal
+`pytest --setup-only` pass. The real `ditto_target_profiles` /
+`ditto_storage_options` fixtures resolve each backend, and ditto renders what the
+pass enumerated. So these commands import your test modules and need the same
+runtime credentials your test run needs, and they are slower than a plain
+directory listing even for local-only projects.
+
+`ditto clean` remains local-only and never touches remote snapshots.
+
 ### `ditto run`
 
 Runs pytest and reports snapshot activity via the ditto session report. Any extra

--- a/src/ditto/_cli_introspect.py
+++ b/src/ditto/_cli_introspect.py
@@ -1,0 +1,46 @@
+"""Drive the in-pytest introspection pass and load its manifest."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from ditto._manifest import Manifest, from_json
+
+# pytest's exit code when collection finds no tests — an empty inventory, not a
+# failure. https://docs.pytest.org/en/stable/reference/exit-codes.html
+_PYTEST_NO_TESTS_COLLECTED = 5
+
+
+class IntrospectError(RuntimeError):
+    """Raised when the pytest introspection pass fails to produce a usable manifest."""
+
+
+def run_introspect(path: Path) -> Manifest:
+    """Run `pytest <path> --setup-only --ditto-introspect=<tmp>` and return the
+    manifest it writes.
+
+    Raises IntrospectError on any error exit (collection/import/setup failure) so
+    an incomplete pass is never mistaken for an empty or complete inventory. A
+    "no tests collected" exit (5) is treated as a legitimately empty inventory.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        manifest_path = Path(tmp) / "manifest.json"
+        completed = subprocess.run(
+            [
+                sys.executable, "-m", "pytest", str(path), "--setup-only", "-q",
+                f"--ditto-introspect={manifest_path}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        ok = completed.returncode in (0, _PYTEST_NO_TESTS_COLLECTED)
+        if not ok or not manifest_path.exists():
+            raise IntrospectError(
+                "ditto introspection pass failed "
+                f"(pytest exit {completed.returncode}):\n"
+                f"{completed.stdout}\n{completed.stderr}"
+            )
+        return from_json(manifest_path.read_text())

--- a/src/ditto/_manifest.py
+++ b/src/ditto/_manifest.py
@@ -1,0 +1,49 @@
+"""The introspection manifest: the inventory shape for CLI rendering.
+
+Written by the in-pytest introspection pass. Carries only enumerated metadata,
+never credentials.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    """One stored snapshot. `modified` is a POSIX timestamp when the backend's
+    filesystem reports one (local files, S3), else None (e.g. Redis)."""
+
+    storage_key: str
+    size_bytes: int
+    modified: float | None
+
+
+@dataclass(frozen=True)
+class BackendManifest:
+    """The snapshots under one resolved backend, keyed by its canonical URI."""
+
+    location: str
+    entries: list[ManifestEntry]
+
+
+# The whole inventory for one CLI invocation: one BackendManifest per resolved
+# backend. A plain list — there is no inventory-level data to justify a wrapper.
+Manifest = list[BackendManifest]
+
+
+def to_json(backends: Manifest) -> str:
+    """Serialize a manifest to a JSON string."""
+    return json.dumps([asdict(b) for b in backends])
+
+
+def from_json(text: str) -> Manifest:
+    """Deserialize a manifest from a JSON string."""
+    return [
+        BackendManifest(
+            location=b["location"],
+            entries=[ManifestEntry(**e) for e in b["entries"]],
+        )
+        for b in json.loads(text)
+    ]

--- a/src/ditto/backends/_fsspec.py
+++ b/src/ditto/backends/_fsspec.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import posixpath
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Iterator, Mapping, MutableMapping
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -9,6 +10,23 @@ if TYPE_CHECKING:
 
 
 __all__ = ("FsspecMapping",)
+
+
+def _info_mtime(info: Mapping[str, object]) -> float | None:
+    """Extract a POSIX mtime from an fsspec info dict, or None if absent.
+
+    Local fs reports `mtime` (float); S3 reports `LastModified` (datetime); GCS
+    `last_modified`. Anything else (memory fs) has no mtime.
+    """
+    match info.get("mtime", info.get("LastModified", info.get("last_modified"))):
+        case bool():  # bool is an int subclass — never a timestamp
+            return None
+        case int() | float() as ts:
+            return float(ts)
+        case datetime() as dt:
+            return dt.timestamp()
+        case _:
+            return None
 
 
 class FsspecMapping(MutableMapping[str, bytes]):
@@ -89,3 +107,18 @@ class FsspecMapping(MutableMapping[str, bytes]):
 
     def __len__(self) -> int:
         return sum(1 for _ in self)
+
+    def stat_entries(self) -> Iterator[tuple[str, int, float | None]]:
+        """Yield (key, size_bytes, modified) for each stored snapshot.
+
+        Uses one `fs.find(detail=True)` listing, so size and mtime come from a
+        single round trip — no per-key reads. `modified` is None when the
+        filesystem reports no mtime. Mirrors `__iter__`'s root-prefix stripping.
+        """
+        if not self._fs.exists(self._root):
+            return
+        prefix = self._root + "/"
+        for path, info in self._fs.find(self._root, detail=True).items():
+            if not path.startswith(prefix):
+                continue
+            yield path[len(prefix) :], int(info.get("size") or 0), _info_mtime(info)

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -50,6 +50,7 @@ from ._theme import (
     MAUVE,
     FLAMINGO,
 )
+from ._manifest import ManifestEntry
 
 
 console = Console()
@@ -123,6 +124,13 @@ def _ext_map(infos: list[RecorderInfo]) -> dict[str, RecorderInfo]:
     return {info.extension: info for info in infos}
 
 
+def _recorder_name(ext: str, ext_map: Mapping[str, RecorderInfo]) -> str:
+    """Map a parsed extension to its recorder name, falling back to the bare ext."""
+    if ext in ext_map:
+        return ext_map[ext].name
+    return ext.lstrip(".")
+
+
 def _human_size(n: int) -> str:
     value: float = n
     for unit in ("B", "KB", "MB", "GB"):
@@ -140,39 +148,34 @@ class SnapshotStats:
     total_count: int
     total_size: int
     by_recorder: Mapping[str, tuple[int, int]]  # name → (count, bytes)
-    oldest: tuple[float, Path] | None
-    newest: tuple[float, Path] | None
+    oldest: tuple[float, str] | None
+    newest: tuple[float, str] | None
 
 
 def gather_stats(
-    files: list[Path], ext_map: Mapping[str, RecorderInfo]
+    entries: list[ManifestEntry], ext_map: Mapping[str, RecorderInfo]
 ) -> SnapshotStats:
-    """Aggregate snapshot file statistics, calling stat() on each file."""
+    """Aggregate snapshot statistics from a list of ManifestEntry items."""
     total_size = 0
     by_recorder: dict[str, tuple[int, int]] = {}
-    oldest: tuple[float, Path] | None = None
-    newest: tuple[float, Path] | None = None
+    oldest: tuple[float, str] | None = None
+    newest: tuple[float, str] | None = None
 
-    for fp in files:
-        stat = fp.stat()
-        sz = stat.st_size
-        mtime = stat.st_mtime
-        total_size += sz
-
-        _, _, ext = _parse_snapshot_name(fp.name)
-        recorder_name = (
-            ext_map[ext].name if ext in ext_map else ext.lstrip(".") if ext else ""
-        )
+    for entry in entries:
+        total_size += entry.size_bytes
+        _, _, ext = _parse_snapshot_name(entry.storage_key)
+        recorder_name = _recorder_name(ext, ext_map)
         count, total = by_recorder.get(recorder_name, (0, 0))
-        by_recorder[recorder_name] = (count + 1, total + sz)
+        by_recorder[recorder_name] = (count + 1, total + entry.size_bytes)
 
-        if oldest is None or mtime < oldest[0]:
-            oldest = (mtime, fp)
-        if newest is None or mtime > newest[0]:
-            newest = (mtime, fp)
+        if entry.modified is not None:
+            if oldest is None or entry.modified < oldest[0]:
+                oldest = (entry.modified, entry.storage_key)
+            if newest is None or entry.modified > newest[0]:
+                newest = (entry.modified, entry.storage_key)
 
     return SnapshotStats(
-        total_count=len(files),
+        total_count=len(entries),
         total_size=total_size,
         by_recorder=by_recorder,
         oldest=oldest,
@@ -204,10 +207,10 @@ def render_stats(stats: SnapshotStats, console: Console) -> None:
         oldest_date = datetime.fromtimestamp(stats.oldest[0]).strftime("%Y-%m-%d")
         newest_date = datetime.fromtimestamp(stats.newest[0]).strftime("%Y-%m-%d")
         lines.append("  Oldest  ", style=MUTED)
-        lines.append(f"{stats.oldest[1].name}  ", style=PATH)
+        lines.append(f"{stats.oldest[1]}  ", style=PATH)
         lines.append(f"{oldest_date}\n", style=MUTED)
         lines.append("  Newest  ", style=MUTED)
-        lines.append(f"{stats.newest[1].name}  ", style=PATH)
+        lines.append(f"{stats.newest[1]}  ", style=PATH)
         lines.append(f"{newest_date}", style=MUTED)
 
     console.print(
@@ -528,22 +531,22 @@ def _doctor_checks() -> list[CheckResult]:
 
 
 def _find_lint_issues(
-    files: list[Path], em: Mapping[str, RecorderInfo]
+    entries: list[ManifestEntry], em: Mapping[str, RecorderInfo]
 ) -> list[LintIssue]:
-    """Return lint issues for a list of snapshot files without any I/O."""
+    """Return lint issues for inventory entries without further I/O."""
     issues: list[LintIssue] = []
-    for fp in files:
-        _, key, ext = _parse_snapshot_name(fp.name)
+    for entry in entries:
+        _, key, ext = _parse_snapshot_name(entry.storage_key)
         if key == "":
             issues.append(
-                LintIssue(filename=fp.name, issue="Malformed name (missing @)")
+                LintIssue(filename=entry.storage_key, issue="Malformed name (missing @)")
             )
         elif ext not in em:
             issues.append(
-                LintIssue(filename=fp.name, issue=f"Unknown extension: {ext!r}")
+                LintIssue(filename=entry.storage_key, issue=f"Unknown extension: {ext!r}")
             )
-        if fp.stat().st_size == 0:
-            issues.append(LintIssue(filename=fp.name, issue="Empty file"))
+        if entry.size_bytes == 0:
+            issues.append(LintIssue(filename=entry.storage_key, issue="Empty file"))
     return issues
 
 

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -50,7 +50,8 @@ from ._theme import (
     MAUVE,
     FLAMINGO,
 )
-from ._manifest import ManifestEntry
+from ._manifest import Manifest, ManifestEntry
+from ._cli_introspect import IntrospectError, run_introspect
 
 
 console = Console()
@@ -90,12 +91,27 @@ def _parse_snapshot_name(filename: str) -> tuple[str, str, str]:
     return group, key, f"{dot}{ext_suffix}"
 
 
-def _find_ditto_files(root: Path) -> list[Path]:
-    return sorted(p for p in root.rglob(".ditto/*") if p.is_file())
-
-
 def _find_ditto_dirs(root: Path) -> list[Path]:
     return sorted(p for p in root.rglob(".ditto") if p.is_dir())
+
+
+def _inventory_or_exit(path: Path) -> Manifest:
+    """Run the introspection pass for PATH, or print the error and exit(1).
+
+    Always introspects: the pytest pass resolves real fixtures and per-test
+    record(target=...) marks, so the inventory covers local file://, remote, and
+    fixture-defined backends with nothing inferred from static config.
+    """
+    try:
+        return run_introspect(path)
+    except IntrospectError as exc:
+        console.print(f"[bold {PRUNED}]Introspection failed:[/bold {PRUNED}] {exc}")
+        sys.exit(1)
+
+
+def _entries(manifest: Manifest) -> list[ManifestEntry]:
+    """Flatten all entries across the manifest's backends."""
+    return [e for b in manifest for e in b.entries]
 
 
 @dataclass(frozen=True)
@@ -323,8 +339,9 @@ def cmd_list(path: Path):
       ditto list
       ditto list tests/ci/
     """
-    files = _find_ditto_files(path)
-    if not files:
+    manifest = _inventory_or_exit(path)
+    entries = _entries(manifest)
+    if not entries:
         console.print(f"[{MUTED}]No snapshot files found.[/{MUTED}]")
         sys.exit(1)
 
@@ -344,17 +361,19 @@ def cmd_list(path: Path):
     table.add_column("Size", justify="right", style=MUTED)
     table.add_column("Modified", style=MUTED)
 
-    for fp in files:
-        group, key, ext = _parse_snapshot_name(fp.name)
-        recorder_name = em[ext].name if ext in em else ext.lstrip(".") if ext else ""
-        stat = fp.stat()
-        size = _human_size(stat.st_size)
-        modified = datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d")
+    for entry in entries:
+        group, key, ext = _parse_snapshot_name(entry.storage_key)
+        recorder_name = _recorder_name(ext, em)
+        modified = (
+            datetime.fromtimestamp(entry.modified).strftime("%Y-%m-%d")
+            if entry.modified is not None
+            else "—"
+        )
         table.add_row(
             group,
             key,
             Text(recorder_name, style=colour_map.get(recorder_name, MUTED)),
-            size,
+            _human_size(entry.size_bytes),
             modified,
         )
 
@@ -419,12 +438,13 @@ def cmd_status(path: Path):
       ditto status
       ditto status tests/ci/
     """
-    files = _find_ditto_files(path)
-    if not files:
+    manifest = _inventory_or_exit(path)
+    entries = _entries(manifest)
+    if not entries:
         console.print(f"[{MUTED}]No snapshot files found.[/{MUTED}]")
         sys.exit(1)
 
-    render_stats(gather_stats(files, _ext_map(_load_recorder_infos())), console)
+    render_stats(gather_stats(entries, _ext_map(_load_recorder_infos())), console)
 
 
 def _render_recorders(infos: list[RecorderInfo], console: Console) -> None:
@@ -550,18 +570,6 @@ def _find_lint_issues(
     return issues
 
 
-def _gather_dir_stats(
-    dirs: list[Path], em: Mapping[str, RecorderInfo]
-) -> list[tuple[Path, SnapshotStats]]:
-    """Return per-directory stats for non-empty .ditto/ dirs, I/O limited to stat()."""
-    result = []
-    for d in dirs:
-        files = sorted(f for f in d.iterdir() if f.is_file())
-        if files:
-            result.append((d, gather_stats(files, em)))
-    return result
-
-
 # ── Doctor / Lint / Stats rendering ───────────────────────────────────────────
 
 
@@ -604,7 +612,7 @@ def _render_lint_issues(issues: list[LintIssue], console: Console) -> None:
 
 
 def _render_stats_table(
-    dir_stats: list[tuple[Path, SnapshotStats]], console: Console
+    dir_stats: list[tuple[str, SnapshotStats]], console: Console
 ) -> None:
     all_names = {name for _, s in dir_stats for name in s.by_recorder}
     colour_map = _build_colour_map(all_names)
@@ -635,7 +643,7 @@ def _render_stats_table(
                 recorder_text.append("  ")
             recorder_text.append(f"{name}×{cnt}", style=colour_map.get(name, MUTED))
         table.add_row(
-            str(d), str(s.total_count), _human_size(s.total_size), recorder_text
+            d, str(s.total_count), _human_size(s.total_size), recorder_text
         )
 
     table.columns[1].footer = str(total_count)
@@ -673,9 +681,8 @@ def cmd_lint(path: Path):
       ditto lint
       ditto lint tests/ci/
     """
-    issues = _find_lint_issues(
-        _find_ditto_files(path), _ext_map(_load_recorder_infos())
-    )
+    manifest = _inventory_or_exit(path)
+    issues = _find_lint_issues(_entries(manifest), _ext_map(_load_recorder_infos()))
     if not issues:
         console.print(f"[{MUTED}]All snapshots are valid.[/{MUTED}]")
         return
@@ -695,10 +702,10 @@ def cmd_stats(path: Path):
       ditto stats
       ditto stats tests/ci/
     """
-    dir_stats = _gather_dir_stats(
-        _find_ditto_dirs(path), _ext_map(_load_recorder_infos())
-    )
-    if not dir_stats:
+    manifest = _inventory_or_exit(path)
+    if not manifest:
         console.print(f"[{MUTED}]No snapshot files found.[/{MUTED}]")
         sys.exit(1)
+    em = _ext_map(_load_recorder_infos())
+    dir_stats = [(b.location, gather_stats(b.entries, em)) for b in manifest]
     _render_stats_table(dir_stats, console)

--- a/src/ditto/plugin.py
+++ b/src/ditto/plugin.py
@@ -16,6 +16,7 @@ import fsspec.core
 
 from ditto.backends import BACKEND_REGISTRY, FsspecMapping
 from ditto.snapshot import SnapshotKey, session_tracker
+from ditto._manifest import BackendManifest, ManifestEntry, to_json
 from ditto._report import render_session_report
 from ditto.recorders import Recorder, RECORDER_REGISTRY, default as _default_recorder
 from ditto.exceptions import (
@@ -48,6 +49,7 @@ StorageOptionsByScheme = dict[str, StorageOptions]
 _session_exit_stack: ExitStack = ExitStack()
 _entered_backends: dict[int, MutableMapping[str, bytes]] = {}
 _backend_cache: dict[TargetCacheKey, MutableMapping[str, bytes]] = {}
+_introspect_backends: dict[str, MutableMapping[str, bytes]] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -511,6 +513,9 @@ def snapshot(request: pytest.FixtureRequest) -> Snapshot:
 
     session_tracker.register_backend_module(id(backend), module)
 
+    if request.config.getoption("--ditto-introspect", default=""):
+        _introspect_backends.setdefault(abs_uri, backend)
+
     file_prefix = str(request.path.relative_to(rootdir)) + "::"
     qualified_name = request.node.nodeid.removeprefix(file_prefix)
     group_name = qualified_name.replace("::", ".")
@@ -543,6 +548,16 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store_true",
         default=False,
         help="After the session, delete snapshot files not accessed during this run.",
+    )
+    group.addoption(
+        "--ditto-introspect",
+        default="",
+        metavar="PATH",
+        help=(
+            "Internal: resolve every test's backend, write a JSON manifest of "
+            "stored snapshots to PATH, then skip pruning. Used by the ditto CLI "
+            "to introspect backends. Combine with --setup-only."
+        ),
     )
     parser.addini(
         "ditto_target",
@@ -590,6 +605,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     _session_exit_stack = ExitStack()
     _entered_backends.clear()
     _backend_cache.clear()
+    _introspect_backends.clear()
     session_tracker.reset()
 
 
@@ -615,8 +631,54 @@ def _keys_for_modules(
     return {k for k in all_keys if any(k.startswith(p) for p in prefixes)}
 
 
+def _enumerate_entries(backend: MutableMapping[str, bytes]) -> list[ManifestEntry]:
+    """Enumerate one backend's stored snapshots as manifest entries.
+
+    fsspec-backed stores report size and mtime from a single listing; generic
+    MutableMapping backends (e.g. Redis) report size via a per-key read and
+    carry no mtime. Enumeration errors are warned and yield an empty backend, so
+    one unreachable store never aborts the whole pass — the backend still appears
+    in the manifest (so the CLI can flag it as empty/misconfigured).
+    """
+    try:
+        if isinstance(backend, FsspecMapping):
+            return [
+                ManifestEntry(storage_key=key, size_bytes=size, modified=modified)
+                for key, size, modified in backend.stat_entries()
+            ]
+        return [
+            ManifestEntry(storage_key=key, size_bytes=len(backend[key]), modified=None)
+            for key in backend
+        ]
+    except Exception as exc:
+        warnings.warn(
+            f"Failed to enumerate backend {backend!r}: {exc}; "
+            "reporting it with no entries.",
+            stacklevel=1,
+        )
+        return []
+
+
+def _write_introspect_manifest(path: str) -> None:
+    """Write a manifest of every resolved backend to `path`.
+
+    Called before the session ExitStack closes, so backends are still open.
+    """
+    manifest = [
+        BackendManifest(location=uri, entries=_enumerate_entries(backend))
+        for uri, backend in _introspect_backends.items()
+    ]
+    Path(path).write_text(to_json(manifest))
+
+
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     config = session.config
+
+    introspect_path = config.getoption("--ditto-introspect", default="")
+    if introspect_path:
+        _write_introspect_manifest(introspect_path)
+        return
+
     do_prune = config.getoption("--ditto-prune", default=False)
 
     pruned: list[str] = []

--- a/tests/ci/test_backends.py
+++ b/tests/ci/test_backends.py
@@ -7,6 +7,7 @@ import uuid
 from collections.abc import Iterator, MutableMapping
 
 import pytest
+from fsspec.implementations.local import LocalFileSystem
 from fsspec.implementations.memory import MemoryFileSystem
 
 from ditto.backends import FsspecMapping, PrefixedMapping, TransformMapping
@@ -408,3 +409,34 @@ def test_routes_io_through_entered_proxy_when_inner_returns_proxy() -> None:
         actual = entered_m["key"]
 
     assert actual == b"val"
+
+
+# ── FsspecMapping.stat_entries ─────────────────────────────────────────────────
+
+
+def test_stat_entries_reports_size_and_mtime_for_local_files(tmp_path) -> None:
+    """stat_entries yields each key with its byte size and a real mtime on local fs."""
+    backend = FsspecMapping(LocalFileSystem(), str(tmp_path / "snaps"))
+    backend["mod.test_a@v.json"] = b"hello"
+
+    by_key = {k: (size, mtime) for k, size, mtime in backend.stat_entries()}
+
+    assert by_key["mod.test_a@v.json"][0] == 5
+    assert by_key["mod.test_a@v.json"][1] is not None
+
+
+def test_stat_entries_is_empty_when_root_is_absent(tmp_path) -> None:
+    """stat_entries yields nothing when the backend root does not exist."""
+    backend = FsspecMapping(LocalFileSystem(), str(tmp_path / "missing"))
+
+    assert list(backend.stat_entries()) == []
+
+
+def test_stat_entries_reports_none_mtime_when_filesystem_has_no_mtime() -> None:
+    """A filesystem that reports no mtime yields modified=None alongside the size."""
+    backend = _mem()
+    backend["mod.test_a@v.json"] = b"hi"
+
+    (entry,) = backend.stat_entries()
+
+    assert (entry[1], entry[2]) == (2, None)

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from ditto._manifest import ManifestEntry
+from click.testing import CliRunner
+
+from ditto import cli as cli_mod
+from ditto._manifest import BackendManifest, ManifestEntry
 from ditto.cli import (
     _RECORDER_PALETTE,
     RecorderInfo,
@@ -10,6 +13,7 @@ from ditto.cli import (
     _ext_map,
     _human_size,
     _parse_snapshot_name,
+    cli,
     gather_stats,
 )
 
@@ -218,3 +222,53 @@ def test_sums_count_and_size_across_entries_of_one_recorder() -> None:
     assert stats.total_count == 3
     assert stats.total_size == 600
     assert stats.by_recorder["pickle"] == (3, 600)
+
+
+# ── command inventory dispatch ─────────────────────────────────────────────────
+
+
+def _patch_inventory(monkeypatch, manifest: list[BackendManifest]) -> None:
+    monkeypatch.setattr(cli_mod, "run_introspect", lambda path: manifest)
+
+
+def test_list_renders_snapshots_from_the_manifest(tmp_path, monkeypatch) -> None:
+    """`ditto list` renders the storage keys the introspection pass enumerated."""
+    manifest = [
+        BackendManifest("file:///x/.ditto", [ManifestEntry("mod.test_y@v.json", 7, None)])
+    ]
+    _patch_inventory(monkeypatch, manifest)
+
+    result = CliRunner().invoke(cli, ["list", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "test_y" in result.output
+
+
+def test_stats_shows_a_configured_backend_even_with_no_snapshots(
+    tmp_path, monkeypatch
+) -> None:
+    """An empty-but-resolved backend still appears in `ditto stats`, flagging it to
+    the user as removable or misconfigured."""
+    manifest = [BackendManifest("redis://h/0", [])]
+    _patch_inventory(monkeypatch, manifest)
+
+    result = CliRunner().invoke(cli, ["stats", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "redis://h/0" in result.output
+
+
+def test_list_reports_failure_and_exits_one_when_introspection_errors(
+    tmp_path, monkeypatch
+) -> None:
+    """A failed introspection pass surfaces an error and a non-zero exit."""
+
+    def _boom(path):
+        raise cli_mod.IntrospectError("pytest blew up")
+
+    monkeypatch.setattr(cli_mod, "run_introspect", _boom)
+
+    result = CliRunner().invoke(cli, ["list", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Introspection failed" in result.output

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import MagicMock
-
-
+from ditto._manifest import ManifestEntry
 from ditto.cli import (
+    _RECORDER_PALETTE,
     RecorderInfo,
     _build_colour_map,
     _ext_map,
@@ -19,187 +17,204 @@ from ditto.cli import (
 # ── _parse_snapshot_name ──────────────────────────────────────────────────────
 
 
-class TestParseSnapshotName:
-    def test_splits_group_key_and_extension(self):
-        """Standard {group}@{key}.{ext} filename is split correctly."""
-        group, key, ext = _parse_snapshot_name("test_foo@result.pickle")
-        assert group == "test_foo"
-        assert key == "result"
-        assert ext == ".pickle"
+def test_splits_group_key_and_extension() -> None:
+    """Standard {group}@{key}.{ext} filename is split correctly."""
+    group, key, ext = _parse_snapshot_name("test_foo@result.pickle")
+    assert group == "test_foo"
+    assert key == "result"
+    assert ext == ".pickle"
 
-    def test_preserves_multi_dot_extension(self):
-        """Extension with multiple dots (e.g. pandas.parquet) is preserved."""
-        group, key, ext = _parse_snapshot_name("test_foo@result.pandas.parquet")
-        assert group == "test_foo"
-        assert key == "result"
-        assert ext == ".pandas.parquet"
 
-    def test_no_at_sign_returns_empty_key_and_ext(self):
-        """A filename with no '@' is treated as group only; key and ext are empty."""
-        group, key, ext = _parse_snapshot_name("invalid_filename")
-        assert group == "invalid_filename"
-        assert key == ""
-        assert ext == ""
+def test_preserves_multi_dot_extension() -> None:
+    """Extension with multiple dots (e.g. pandas.parquet) is preserved."""
+    group, key, ext = _parse_snapshot_name("test_foo@result.pandas.parquet")
+    assert group == "test_foo"
+    assert key == "result"
+    assert ext == ".pandas.parquet"
 
-    def test_returns_empty_extension_when_no_dot_follows_at(self):
-        """A file like 'group@key' (no dot) yields an empty ext."""
-        group, key, ext = _parse_snapshot_name("test_foo@key_only")
-        assert group == "test_foo"
-        assert key == "key_only"
-        assert ext == ""
 
-    def test_preserves_dots_in_group_portion(self):
-        """Group portion (before @) may itself contain dots (unittest class names)."""
-        group, key, ext = _parse_snapshot_name("MyTestCase.test_method@snap.yaml")
-        assert group == "MyTestCase.test_method"
-        assert key == "snap"
-        assert ext == ".yaml"
+def test_no_at_sign_returns_empty_key_and_ext() -> None:
+    """A filename with no '@' is treated as group only; key and ext are empty."""
+    group, key, ext = _parse_snapshot_name("invalid_filename")
+    assert group == "invalid_filename"
+    assert key == ""
+    assert ext == ""
+
+
+def test_returns_empty_extension_when_no_dot_follows_at() -> None:
+    """A file like 'group@key' (no dot) yields an empty ext."""
+    group, key, ext = _parse_snapshot_name("test_foo@key_only")
+    assert group == "test_foo"
+    assert key == "key_only"
+    assert ext == ""
+
+
+def test_preserves_dots_in_group_portion() -> None:
+    """Group portion (before @) may itself contain dots (unittest class names)."""
+    group, key, ext = _parse_snapshot_name("MyTestCase.test_method@snap.yaml")
+    assert group == "MyTestCase.test_method"
+    assert key == "snap"
+    assert ext == ".yaml"
 
 
 # ── _human_size ───────────────────────────────────────────────────────────────
 
 
-class TestHumanSize:
-    def test_formats_with_bytes_suffix_when_under_one_kb(self):
-        assert _human_size(0) == "0 B"
-        assert _human_size(512) == "512 B"
-        assert _human_size(1023) == "1023 B"
+def test_formats_with_bytes_suffix_when_under_one_kb() -> None:
+    """Values below 1 KB are rendered with a plain byte suffix."""
+    assert _human_size(0) == "0 B"
+    assert _human_size(512) == "512 B"
+    assert _human_size(1023) == "1023 B"
 
-    def test_formats_with_kb_suffix_at_kilobyte_boundary(self):
-        assert _human_size(1024) == "1.0 KB"
-        assert _human_size(2048) == "2.0 KB"
 
-    def test_formats_with_mb_suffix_at_megabyte_boundary(self):
-        assert _human_size(1024 * 1024) == "1.0 MB"
+def test_formats_with_kb_suffix_at_kilobyte_boundary() -> None:
+    """Values at or above 1 KB are rendered in kilobytes."""
+    assert _human_size(1024) == "1.0 KB"
+    assert _human_size(2048) == "2.0 KB"
 
-    def test_formats_with_gb_suffix_at_gigabyte_boundary(self):
-        assert _human_size(1024**3) == "1.0 GB"
 
-    def test_formats_with_tb_suffix_at_terabyte_boundary(self):
-        assert _human_size(1024**4) == "1.0 TB"
+def test_formats_with_mb_suffix_at_megabyte_boundary() -> None:
+    """Values at the megabyte boundary are rendered in megabytes."""
+    assert _human_size(1024 * 1024) == "1.0 MB"
 
-    def test_formats_fractional_kilobytes(self):
-        # 1536 bytes = 1.5 KB
-        assert _human_size(1536) == "1.5 KB"
+
+def test_formats_with_gb_suffix_at_gigabyte_boundary() -> None:
+    """Values at the gigabyte boundary are rendered in gigabytes."""
+    assert _human_size(1024**3) == "1.0 GB"
+
+
+def test_formats_with_tb_suffix_at_terabyte_boundary() -> None:
+    """Values at the terabyte boundary are rendered in terabytes."""
+    assert _human_size(1024**4) == "1.0 TB"
+
+
+def test_formats_fractional_kilobytes() -> None:
+    """A sub-kilobyte fraction is rendered to one decimal place (1536 B = 1.5 KB)."""
+    assert _human_size(1536) == "1.5 KB"
 
 
 # ── _build_colour_map ─────────────────────────────────────────────────────────
 
 
-class TestBuildColourMap:
-    def test_empty_input_returns_empty_map(self):
-        assert _build_colour_map([]) == {}
+def test_colour_map_is_empty_for_no_names() -> None:
+    """An empty name iterable produces an empty colour map."""
+    assert _build_colour_map([]) == {}
 
-    def test_single_name_gets_first_palette_colour(self):
-        result = _build_colour_map(["pickle"])
-        assert "pickle" in result
-        assert isinstance(result["pickle"], str)
 
-    def test_assignment_is_deterministic_by_sorted_order(self):
-        names = ["yaml", "pickle", "json"]
-        result1 = _build_colour_map(names)
-        result2 = _build_colour_map(reversed(names))
-        # Same colour assignment regardless of input order
-        assert result1 == result2
+def test_single_name_gets_a_palette_colour() -> None:
+    """A single name is assigned a string palette colour."""
+    result = _build_colour_map(["pickle"])
+    assert "pickle" in result
+    assert isinstance(result["pickle"], str)
 
-    def test_assigns_palette_colours_in_alphabetical_order(self):
-        """First sorted name gets palette[0], second gets palette[1]."""
-        from ditto.cli import _RECORDER_PALETTE
 
-        result = _build_colour_map(["zz", "aa"])
-        assert result["aa"] == _RECORDER_PALETTE[0]
-        assert result["zz"] == _RECORDER_PALETTE[1]
+def test_colour_assignment_is_independent_of_input_order() -> None:
+    """The same names yield the same colour assignment regardless of order."""
+    names = ["yaml", "pickle", "json"]
+    assert _build_colour_map(names) == _build_colour_map(list(reversed(names)))
+
+
+def test_assigns_palette_colours_in_alphabetical_order() -> None:
+    """First sorted name gets palette[0], second gets palette[1]."""
+    result = _build_colour_map(["zz", "aa"])
+    assert result["aa"] == _RECORDER_PALETTE[0]
+    assert result["zz"] == _RECORDER_PALETTE[1]
 
 
 # ── _ext_map ──────────────────────────────────────────────────────────────────
 
 
-class TestExtMap:
-    def test_maps_extension_to_recorder_info(self):
-        infos = [
-            RecorderInfo(name="pickle", extension=".pickle", package="pytest-ditto"),
-            RecorderInfo(name="yaml", extension=".yaml", package="pytest-ditto"),
-        ]
-        result = _ext_map(infos)
-        assert result[".pickle"].name == "pickle"
-        assert result[".yaml"].name == "yaml"
+def test_maps_extension_to_recorder_info() -> None:
+    """Each RecorderInfo is keyed by its extension."""
+    infos = [
+        RecorderInfo(name="pickle", extension=".pickle", package="pytest-ditto"),
+        RecorderInfo(name="yaml", extension=".yaml", package="pytest-ditto"),
+    ]
+    result = _ext_map(infos)
+    assert result[".pickle"].name == "pickle"
+    assert result[".yaml"].name == "yaml"
 
-    def test_empty_list_returns_empty_map(self):
-        assert _ext_map([]) == {}
 
-    def test_later_entry_wins_on_duplicate_extension(self):
-        """Last info with a given extension is kept (dict overwrite semantics)."""
-        a = RecorderInfo(name="first", extension=".pkl", package="pkg-a")
-        b = RecorderInfo(name="second", extension=".pkl", package="pkg-b")
-        result = _ext_map([a, b])
-        assert result[".pkl"].name == "second"
+def test_ext_map_is_empty_for_no_infos() -> None:
+    """An empty info list produces an empty extension map."""
+    assert _ext_map([]) == {}
+
+
+def test_later_entry_wins_on_duplicate_extension() -> None:
+    """Last info with a given extension is kept (dict overwrite semantics)."""
+    a = RecorderInfo(name="first", extension=".pkl", package="pkg-a")
+    b = RecorderInfo(name="second", extension=".pkl", package="pkg-b")
+    result = _ext_map([a, b])
+    assert result[".pkl"].name == "second"
 
 
 # ── gather_stats ──────────────────────────────────────────────────────────────
 
 
-def _mock_file(name: str, size: int, mtime: float) -> Path:
-    """Return a Path-like mock with a working stat()."""
-    p = MagicMock(spec=Path)
-    p.name = name
-    stat = MagicMock()
-    stat.st_size = size
-    stat.st_mtime = mtime
-    p.stat.return_value = stat
-    return p
+def test_attributes_entry_to_recorder_when_extension_is_known() -> None:
+    """An entry with a mapped extension is attributed to its recorder."""
+    em = {".pickle": RecorderInfo("pickle", ".pickle", "pytest-ditto")}
+    entries = [ManifestEntry("test_foo@snap.pickle", size_bytes=100, modified=1000.0)]
+
+    stats = gather_stats(entries, em)
+
+    assert stats.total_count == 1
+    assert stats.total_size == 100
+    assert stats.by_recorder["pickle"] == (1, 100)
 
 
-class TestGatherStats:
-    def test_attributes_file_to_recorder_when_extension_is_known(self):
-        """A file with a mapped extension is attributed to its recorder."""
-        f = _mock_file("test_foo@snap.pickle", size=100, mtime=1000.0)
-        em = {".pickle": RecorderInfo("pickle", ".pickle", "pytest-ditto")}
+def test_attributes_unknown_extension_to_its_raw_name() -> None:
+    """An unmapped extension uses the extension (minus leading dot) as recorder name."""
+    entries = [ManifestEntry("test_foo@snap.custom", size_bytes=50, modified=None)]
 
-        stats = gather_stats([f], em)
+    stats = gather_stats(entries, ext_map={})
 
-        assert stats.total_count == 1
-        assert stats.total_size == 100
-        assert "pickle" in stats.by_recorder
-        assert stats.by_recorder["pickle"] == (1, 100)
+    assert "custom" in stats.by_recorder
 
-    def test_unknown_extension_falls_back_to_raw_name(self):
-        """An unmapped extension uses the extension (minus leading dot) as recorder
-        name."""
-        f = _mock_file("test_foo@snap.custom", size=50, mtime=500.0)
 
-        stats = gather_stats([f], ext_map={})
+def test_buckets_entry_with_no_extension_under_empty_string() -> None:
+    """An entry parsed with no extension falls into the '' recorder bucket."""
+    entries = [ManifestEntry("invalid_name", size_bytes=10, modified=None)]
 
-        assert "custom" in stats.by_recorder
+    stats = gather_stats(entries, ext_map={})
 
-    def test_no_extension_uses_empty_string_key(self):
-        """A file parsed with no extension falls into the '' recorder bucket."""
-        f = _mock_file("invalid_filename", size=10, mtime=200.0)
+    assert "" in stats.by_recorder
 
-        stats = gather_stats([f], ext_map={})
 
-        assert "" in stats.by_recorder
+def test_tracks_oldest_and_newest_by_mtime_when_present() -> None:
+    """oldest and newest are the entries with the min/max modified timestamp."""
+    entries = [
+        ManifestEntry("test_a@x.pickle", size_bytes=10, modified=100.0),
+        ManifestEntry("test_b@y.pickle", size_bytes=20, modified=999.0),
+    ]
 
-    def test_tracks_oldest_and_newest_files_by_mtime(self):
-        """oldest and newest are set to the files with the min/max mtime."""
-        old_f = _mock_file("test_a@x.pickle", size=10, mtime=100.0)
-        new_f = _mock_file("test_b@y.pickle", size=20, mtime=999.0)
+    stats = gather_stats(entries, ext_map={})
 
-        stats = gather_stats([old_f, new_f], ext_map={})
+    assert stats.oldest[0] == 100.0
+    assert stats.newest[0] == 999.0
 
-        assert stats.oldest[0] == 100.0
-        assert stats.newest[0] == 999.0
 
-    def test_aggregates_multiple_files_same_recorder(self):
-        """Multiple files of the same recorder type are summed correctly."""
-        files = [
-            _mock_file("test_a@s.pickle", size=100, mtime=1.0),
-            _mock_file("test_b@s.pickle", size=200, mtime=2.0),
-            _mock_file("test_c@s.pickle", size=300, mtime=3.0),
-        ]
-        em = {".pickle": RecorderInfo("pickle", ".pickle", "pytest-ditto")}
+def test_leaves_oldest_and_newest_unset_when_no_entry_has_mtime() -> None:
+    """Remote entries (modified=None) leave oldest/newest as None."""
+    entries = [ManifestEntry("test_a@x.pickle", size_bytes=10, modified=None)]
 
-        stats = gather_stats(files, em)
+    stats = gather_stats(entries, ext_map={})
 
-        assert stats.total_count == 3
-        assert stats.total_size == 600
-        assert stats.by_recorder["pickle"] == (3, 600)
+    assert stats.oldest is None
+    assert stats.newest is None
+
+
+def test_sums_count_and_size_across_entries_of_one_recorder() -> None:
+    """Multiple entries of the same recorder type are summed correctly."""
+    em = {".pickle": RecorderInfo("pickle", ".pickle", "pytest-ditto")}
+    entries = [
+        ManifestEntry("test_a@s.pickle", size_bytes=100, modified=1.0),
+        ManifestEntry("test_b@s.pickle", size_bytes=200, modified=2.0),
+        ManifestEntry("test_c@s.pickle", size_bytes=300, modified=3.0),
+    ]
+
+    stats = gather_stats(entries, em)
+
+    assert stats.total_count == 3
+    assert stats.total_size == 600
+    assert stats.by_recorder["pickle"] == (3, 600)

--- a/tests/ci/test_cli_commands.py
+++ b/tests/ci/test_cli_commands.py
@@ -3,18 +3,17 @@ consistency fixes on list/status/clean/recorders."""
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
+from ditto._manifest import ManifestEntry
 from ditto.cli import (
     RecorderInfo,
     _doctor_checks,
     _ext_map,
     _find_lint_issues,
-    _gather_dir_stats,
     cmd_clean,
     cmd_list,
     cmd_recorders,
@@ -44,15 +43,6 @@ def _entry_points(*, pytest11=(), recorders=(), marks=()):
         "ditto_marks": list(marks),
     }
     return lambda group: mapping.get(group, [])
-
-
-def _make_ditto_dir(root: Path, subdir: str, files: dict[str, bytes]) -> Path:
-    """Create a .ditto/ directory under root/subdir and populate it."""
-    d = root / subdir / ".ditto"
-    d.mkdir(parents=True)
-    for name, content in files.items():
-        (d / name).write_bytes(content)
-    return d
 
 
 @pytest.fixture()
@@ -178,126 +168,59 @@ def test_returns_one_result_per_mark_entry_point() -> None:
 # ── _find_lint_issues: clean inputs ───────────────────────────────────────────
 
 
-def test_returns_no_issues_for_empty_file_list(pickle_ext_map) -> None:
-    """No files means no issues."""
+def test_returns_no_issues_for_empty_entry_list(pickle_ext_map) -> None:
+    """No entries means no issues."""
     assert _find_lint_issues([], pickle_ext_map) == []
 
 
-def test_returns_no_issues_for_valid_snapshot_file(tmp_path, pickle_ext_map) -> None:
-    """A correctly named, non-empty file with a known extension produces no issues."""
-    fp = tmp_path / "test_foo@result.pkl"
-    fp.write_bytes(b"data")
+def test_returns_no_issues_for_valid_entry(pickle_ext_map) -> None:
+    """A well-named, non-empty entry with a known extension produces no issues."""
+    entry = ManifestEntry("test_foo@result.pkl", size_bytes=4, modified=None)
 
-    actual = _find_lint_issues([fp], pickle_ext_map)
-
-    assert actual == []
+    assert _find_lint_issues([entry], pickle_ext_map) == []
 
 
 # ── _find_lint_issues: issue detection ────────────────────────────────────────
 
 
-def test_reports_malformed_name_when_filename_has_no_at_sign(
-    tmp_path, pickle_ext_map
-) -> None:
-    """A filename without '@' is flagged as malformed."""
-    fp = tmp_path / "no_at_sign.pkl"
-    fp.write_bytes(b"data")
+def test_reports_malformed_name_when_key_has_no_at_sign(pickle_ext_map) -> None:
+    """A storage key without '@' is flagged as malformed."""
+    entry = ManifestEntry("no_at_sign.pkl", size_bytes=4, modified=None)
 
-    issues = _find_lint_issues([fp], pickle_ext_map)
+    issues = _find_lint_issues([entry], pickle_ext_map)
 
     assert len(issues) == 1
     assert issues[0].filename == "no_at_sign.pkl"
     assert "Malformed" in issues[0].issue
 
 
-def test_reports_unknown_extension_when_ext_not_in_ext_map(tmp_path) -> None:
-    """A snapshot file with an unregistered extension is flagged as unknown format."""
-    fp = tmp_path / "test_foo@result.mystery"
-    fp.write_bytes(b"data")
+def test_reports_unknown_extension_when_ext_not_in_ext_map() -> None:
+    """An entry with an unregistered extension is flagged as unknown format."""
+    entry = ManifestEntry("test_foo@result.mystery", size_bytes=4, modified=None)
 
-    issues = _find_lint_issues([fp], {})
+    issues = _find_lint_issues([entry], {})
 
     assert len(issues) == 1
     assert "Unknown extension" in issues[0].issue
 
 
-def test_reports_empty_file_when_size_is_zero(tmp_path, pickle_ext_map) -> None:
-    """A zero-byte snapshot file is flagged as empty."""
-    fp = tmp_path / "test_foo@result.pkl"
-    fp.write_bytes(b"")
+def test_reports_empty_file_when_size_is_zero(pickle_ext_map) -> None:
+    """A zero-byte entry is flagged as empty."""
+    entry = ManifestEntry("test_foo@result.pkl", size_bytes=0, modified=None)
 
-    issues = _find_lint_issues([fp], pickle_ext_map)
+    issues = _find_lint_issues([entry], pickle_ext_map)
 
     assert any(i.issue == "Empty file" for i in issues)
 
 
-def test_reports_empty_file_independently_of_unknown_extension(tmp_path) -> None:
-    """An empty file with an unknown extension produces two separate issues."""
-    fp = tmp_path / "test_foo@result.mystery"
-    fp.write_bytes(b"")
+def test_reports_empty_and_unknown_extension_as_separate_issues() -> None:
+    """An empty entry with an unknown extension produces two separate issues."""
+    entry = ManifestEntry("test_foo@result.mystery", size_bytes=0, modified=None)
 
-    issues = _find_lint_issues([fp], {})
+    issue_texts = {i.issue for i in _find_lint_issues([entry], {})}
 
-    issue_texts = {i.issue for i in issues}
     assert any("Unknown extension" in t for t in issue_texts)
     assert any("Empty file" in t for t in issue_texts)
-
-
-# ── _gather_dir_stats ─────────────────────────────────────────────────────────
-
-
-def test_returns_empty_when_given_no_dirs() -> None:
-    """An empty directory list produces no results."""
-    assert _gather_dir_stats([], {}) == []
-
-
-def test_returns_empty_when_all_ditto_dirs_contain_no_files(tmp_path) -> None:
-    """A .ditto/ directory with no files is excluded from the results."""
-    empty = tmp_path / ".ditto"
-    empty.mkdir()
-
-    actual = _gather_dir_stats([empty], {})
-
-    assert actual == []
-
-
-def test_returns_one_entry_per_non_empty_ditto_dir(tmp_path) -> None:
-    """Each .ditto/ directory that contains files produces one entry in the result."""
-    dir_a = _make_ditto_dir(tmp_path, "a", {"test@snap.pkl": b"x"})
-    dir_b = _make_ditto_dir(tmp_path, "b", {"test@snap.pkl": b"y"})
-
-    actual = _gather_dir_stats([dir_a, dir_b], {})
-
-    assert len(actual) == 2
-
-
-def test_stats_reflect_file_count_in_directory(tmp_path) -> None:
-    """The SnapshotStats for a directory reports the correct number of files."""
-    d = _make_ditto_dir(
-        tmp_path,
-        "tests",
-        {
-            "test_a@snap.pkl": b"aaa",
-            "test_b@snap.pkl": b"bb",
-        },
-    )
-
-    actual = _gather_dir_stats([d], {})
-
-    _, stats = actual[0]
-    assert stats.total_count == 2
-
-
-def test_skips_empty_dir_and_includes_populated_dir(tmp_path) -> None:
-    """An empty .ditto/ dir is skipped while a populated one is included."""
-    populated = _make_ditto_dir(tmp_path, "a", {"test@snap.pkl": b"data"})
-    empty = tmp_path / "b" / ".ditto"
-    empty.mkdir(parents=True)
-
-    actual = _gather_dir_stats([populated, empty], {})
-
-    assert len(actual) == 1
-    assert actual[0][0] == populated
 
 
 # ── exit code consistency ─────────────────────────────────────────────────────

--- a/tests/ci/test_cli_commands.py
+++ b/tests/ci/test_cli_commands.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from ditto import cli as cli_mod
 from ditto._manifest import ManifestEntry
 from ditto.cli import (
     RecorderInfo,
@@ -226,15 +227,19 @@ def test_reports_empty_and_unknown_extension_as_separate_issues() -> None:
 # ── exit code consistency ─────────────────────────────────────────────────────
 
 
-def test_list_exits_one_when_no_snapshot_files_exist(tmp_path) -> None:
-    """ditto list exits 1 when no snapshot files are found under the given path."""
+def test_list_exits_one_when_no_snapshots_exist(tmp_path, monkeypatch) -> None:
+    """ditto list exits 1 when the inventory is empty."""
+    monkeypatch.setattr(cli_mod, "run_introspect", lambda path: [])
+
     result = CliRunner().invoke(cmd_list, [str(tmp_path)])
 
     assert result.exit_code == 1
 
 
-def test_status_exits_one_when_no_snapshot_files_exist(tmp_path) -> None:
-    """ditto status exits 1 when no snapshot files are found under the given path."""
+def test_status_exits_one_when_no_snapshots_exist(tmp_path, monkeypatch) -> None:
+    """ditto status exits 1 when the inventory is empty."""
+    monkeypatch.setattr(cli_mod, "run_introspect", lambda path: [])
+
     result = CliRunner().invoke(cmd_status, [str(tmp_path)])
 
     assert result.exit_code == 1

--- a/tests/ci/test_cli_introspect.py
+++ b/tests/ci/test_cli_introspect.py
@@ -1,0 +1,52 @@
+"""Tests for the CLI introspection-pass driver."""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from ditto._cli_introspect import IntrospectError, run_introspect
+
+
+def test_returns_entries_for_a_file_profile(tmp_path) -> None:
+    """run_introspect drives a real pytest pass and returns the enumerated keys,
+    with size and mtime recovered for the local file:// backend."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.pytest.ini_options]\n"
+        'ditto_target_profile = "local"\n'
+        "[tool.pytest-ditto.target_profiles]\n"
+        'local = "file://.snaps"\n'
+    )
+    (tmp_path / "test_thing.py").write_text(
+        textwrap.dedent("""
+            import ditto
+
+            @ditto.record("json")
+            def test_thing(snapshot):
+                assert snapshot({"a": 1}, key="v") == {"a": 1}
+        """)
+    )
+    subprocess.run([sys.executable, "-m", "pytest", "-q"], cwd=tmp_path, check=True)
+
+    manifest = run_introspect(tmp_path)
+
+    entries = [e for b in manifest for e in b.entries]
+    recorded = next(e for e in entries if e.storage_key.endswith("test_thing@v.json"))
+    assert recorded.size_bytes > 0
+    assert recorded.modified is not None  # local fs reports mtime
+
+
+def test_returns_empty_manifest_when_no_tests_are_collected(tmp_path) -> None:
+    """A path with no tests yields an empty manifest, not an error (pytest exit 5)."""
+    manifest = run_introspect(tmp_path)
+
+    assert manifest == []
+
+
+def test_raises_when_the_pytest_pass_errors(tmp_path) -> None:
+    """A collection error raises IntrospectError, never a silent partial manifest."""
+    (tmp_path / "test_broken.py").write_text("import does_not_exist\n")
+
+    with pytest.raises(IntrospectError):
+        run_introspect(tmp_path)

--- a/tests/ci/test_introspect.py
+++ b/tests/ci/test_introspect.py
@@ -1,0 +1,54 @@
+"""Integration tests for the --ditto-introspect pass."""
+
+import json
+
+
+def test_introspect_pass_enumerates_a_fixture_resolved_generic_backend(pytester, tmp_path):
+    """--setup-only --ditto-introspect resolves a fixture-defined generic
+    MutableMapping backend and enumerates its stored keys into a manifest,
+    without running test bodies."""
+    pytester.makeconftest("""
+        import pytest
+        from collections.abc import MutableMapping
+        from ditto.backends import BACKEND_REGISTRY
+
+        # Pre-seeded so the introspect pass has something to enumerate without
+        # relying on a prior recording run persisting module state.
+        _STORE = {"persist://shared": {"mod/test_seeded@v.json": b'{"x": 1}'}}
+
+        class _DictBackend(MutableMapping):
+            def __init__(self, uri, **kwargs):
+                self._d = _STORE.setdefault(uri, {})
+            def __getitem__(self, k): return self._d[k]
+            def __setitem__(self, k, v): self._d[k] = v
+            def __delitem__(self, k): del self._d[k]
+            def __iter__(self): return iter(self._d)
+            def __len__(self): return len(self._d)
+
+        BACKEND_REGISTRY["persist"] = _DictBackend
+
+        @pytest.fixture(scope="session")
+        def ditto_target_profiles():
+            return {"remote": "persist://shared"}
+    """)
+    pytester.makepyfile("""
+        import ditto
+
+        @ditto.record("json", target_profile="remote")
+        def test_inner(snapshot):
+            assert snapshot({"x": 1}, key="v") == {"x": 1}
+    """)
+
+    manifest_path = tmp_path / "manifest.json"
+    result = pytester.runpytest("--setup-only", f"--ditto-introspect={manifest_path}")
+
+    assert result.ret == 0
+    backends = json.loads(manifest_path.read_text())  # to_json emits a bare array
+    assert len(backends) == 1
+    assert backends[0]["location"] == "persist://shared"
+
+    entries = backends[0]["entries"]
+    seeded = next(e for e in entries if e["storage_key"] == "mod/test_seeded@v.json")
+    # Generic mapping: size measured by a read, no mtime.
+    assert seeded["size_bytes"] > 0
+    assert seeded["modified"] is None

--- a/tests/ci/test_manifest.py
+++ b/tests/ci/test_manifest.py
@@ -1,0 +1,31 @@
+"""Behavioural tests for the introspection manifest schema."""
+
+from ditto._manifest import (
+    BackendManifest,
+    ManifestEntry,
+    from_json,
+    to_json,
+)
+
+
+def test_round_trips_a_populated_manifest_through_json() -> None:
+    """Backends and entries survive JSON serialization unchanged."""
+    manifest = [
+        BackendManifest(
+            location="redis://localhost:6379/0",
+            entries=[ManifestEntry("m/test_foo@v.pkl", size_bytes=128, modified=None)],
+        )
+    ]
+
+    actual = from_json(to_json(manifest))
+
+    assert actual == manifest
+
+
+def test_round_trips_an_empty_manifest_through_json() -> None:
+    """An empty backend list serializes and deserializes to an equal value."""
+    manifest: list[BackendManifest] = []
+
+    actual = from_json(to_json(manifest))
+
+    assert actual == manifest


### PR DESCRIPTION
## Summary

Makes `ditto list`, `status`, `stats`, and `lint` work for snapshots in remote and registered backends (S3, Redis, PostgreSQL, …), not just local `file://`.

These commands now always run an internal `pytest --setup-only --ditto-introspect=<path>` pass. The real `snapshot` fixture resolves each test's backend — with full fixture access and per-test `record(target=...)` mark visibility — a session-finish hook enumerates each resolved backend, and writes a JSON manifest that the renderers consume. Because the pass sees every backend a real test run would touch, nothing is inferred from static config and no snapshot is silently missed.

There is deliberately **no static local-vs-remote fast path**: a config-only decision can't see per-test marks, so it would miss mark-redirected remote snapshots. For a testing plugin, correctness wins over the speed of an `rglob`. Local `file://` backends are enumerated by the same pass; size and mtime are recovered from a single `fs.find(detail=True)` listing, so the `Modified` column and oldest/newest stats are preserved with no per-key reads.

`ditto clean` stays local-only and never touches remote snapshots.

## Changes

- `src/ditto/_manifest.py` (new) — the inventory shape: `ManifestEntry`, `BackendManifest`, `Manifest = list[BackendManifest]`, JSON (de)serialization.
- `src/ditto/backends/_fsspec.py` — `FsspecMapping.stat_entries()`: one-listing `(key, size, mtime)` enumeration.
- `src/ditto/plugin.py` — `--ditto-introspect` option, a session collector of resolved backends, and a session-finish writer (fsspec backends via `stat_entries`; generic mappings via a per-key read with `modified=None`).
- `src/ditto/_cli_introspect.py` (new) — `run_introspect` subprocess driver; treats pytest exit 5 (no tests collected) as an empty inventory and raises `IntrospectError` on real failures.
- `src/ditto/cli.py` — `gather_stats`/`_find_lint_issues` consume `ManifestEntry`; `_inventory_or_exit`/`_entries` helpers; the four read commands routed through the pass; dead local-walk helpers removed; `stats` now shows resolved-but-empty backends.

## Testing

- `pixi run -e py312 test tests/ci/` — 254 passed, 2 skipped, 2 xfailed.
- New: `tests/ci/test_manifest.py`, `stat_entries` tests in `test_backends.py`, `test_introspect.py`, `test_cli_introspect.py` (real pytest subprocesses), command-dispatch tests in `test_cli.py`/`test_cli_commands.py`.
- Existing `gather_stats`/`_find_lint_issues` tests migrated to `ManifestEntry`; `test_cli.py` de-classed to module-level functions.
- End-to-end smoke-tested the installed `ditto list`/`stats` binary against a throwaway project.

## Follow-up

- #74 — the plugin's static `target_profiles` are read only from `pyproject.toml` (pre-existing; unrelated to this PR's CLI path).

## Note on commits

This branch replays the 7 introspection commits onto current `main`; the target-profiles base (#73) is already merged.