### PR TITLE
Add `ruff` linting CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,25 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          pixi-version: v0.69.0
+          cache: true
+          environments: lint
+
+      - name: Run ruff
+        run: pixi run -e lint ruff-lint
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ preview = true
 src = ["src/ditto"]
 line-length = 88
 target-version = "py312"
+exclude = ["src/ditto/_version.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "PERF", "W"]
@@ -147,6 +148,7 @@ convention = "numpy"
 [tool.basedpyright]
 pythonVersion = "3.12"
 typeCheckingMode = "standard"
+include = ["src"]
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]
@@ -164,7 +166,8 @@ basedpyright = ">=1.29"
 
 [tool.pixi.feature.lint.tasks]
 lint = "pre-commit run --all"
-typecheck = "basedpyright src/"
+typecheck = "pre-commit run basedpyright --all-files"
+ruff-lint = "pre-commit run ruff-check --all-files"
 
 [tool.pixi.feature.test.dependencies]
 pytest = ">=8.3,<9"

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -559,11 +559,17 @@ def _find_lint_issues(
         _, key, ext = _parse_snapshot_name(entry.storage_key)
         if key == "":
             issues.append(
-                LintIssue(filename=entry.storage_key, issue="Malformed name (missing @)")
+                LintIssue(
+                    filename=entry.storage_key,
+                    issue="Malformed name (missing @)",
+                )
             )
         elif ext not in em:
             issues.append(
-                LintIssue(filename=entry.storage_key, issue=f"Unknown extension: {ext!r}")
+                LintIssue(
+                    filename=entry.storage_key,
+                    issue=f"Unknown extension: {ext!r}",
+                )
             )
         if entry.size_bytes == 0:
             issues.append(LintIssue(filename=entry.storage_key, issue="Empty file"))

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -234,7 +234,10 @@ def _patch_inventory(monkeypatch, manifest: list[BackendManifest]) -> None:
 def test_list_renders_snapshots_from_the_manifest(tmp_path, monkeypatch) -> None:
     """`ditto list` renders the storage keys the introspection pass enumerated."""
     manifest = [
-        BackendManifest("file:///x/.ditto", [ManifestEntry("mod.test_y@v.json", 7, None)])
+        BackendManifest(
+            "file:///x/.ditto",
+            [ManifestEntry("mod.test_y@v.json", 7, None)],
+        )
     ]
     _patch_inventory(monkeypatch, manifest)
 

--- a/tests/ci/test_fixture.py
+++ b/tests/ci/test_fixture.py
@@ -34,7 +34,8 @@ def test_returns_stored_value_on_subsequent_calls(snapshot) -> None:
     """snapshot returns the stored value, not the argument, when the file exists."""
     key = "read"
 
-    # tests/ci/.ditto/tests.ci.test_fixture.test_returns_stored_value_on_subsequent_calls@read.pkl
+    # tests/ci/.ditto/tests.ci.test_fixture\
+    #   .test_returns_stored_value_on_subsequent_calls@read.pkl
     # is committed and contains "read-value". Passing a different argument proves the
     # stored value is returned rather than the argument.
     actual = snapshot("different-value", key=key)

--- a/tests/ci/test_introspect.py
+++ b/tests/ci/test_introspect.py
@@ -3,7 +3,9 @@
 import json
 
 
-def test_introspect_pass_enumerates_a_fixture_resolved_generic_backend(pytester, tmp_path):
+def test_introspect_pass_enumerates_a_fixture_resolved_generic_backend(
+    pytester, tmp_path
+):
     """--setup-only --ditto-introspect resolves a fixture-defined generic
     MutableMapping backend and enumerates its stored keys into a manifest,
     without running test bodies."""

--- a/tests/ci/test_plugin_helpers.py
+++ b/tests/ci/test_plugin_helpers.py
@@ -496,7 +496,8 @@ def test_raises_when_profile_storage_options_is_not_a_mapping() -> None:
 
 
 def test_raises_when_profile_mapping_has_unknown_keys() -> None:
-    """A profile mapping key other than uri/storage_options raises DittoInvalidProfileError."""
+    """A profile mapping key other than uri/storage_options raises
+    DittoInvalidProfileError."""
     profiles = {"bad": {"uri": "s3://east-bucket/", "storage_optoins": {}}}
 
     with pytest.raises(DittoInvalidProfileError, match="unknown key.*storage_optoins"):

--- a/tests/ci/test_profiles.py
+++ b/tests/ci/test_profiles.py
@@ -25,7 +25,8 @@ def test_target_profile_mark_resolves_to_configured_uri(pytester) -> None:
 
 
 def test_ditto_target_profile_ini_is_used_when_mark_has_no_target(pytester) -> None:
-    """ditto_target_profile ini selects the default profile when the mark carries no target."""
+    """ditto_target_profile ini selects the default profile when the mark
+    carries no target."""
     pytester.makeconftest("""
         import pytest
 
@@ -89,7 +90,8 @@ def test_mark_target_uri_takes_precedence_over_ditto_target_profile_ini(
 def test_profile_storage_options_are_not_merged_with_ditto_storage_options(
     pytester,
 ) -> None:
-    """Profile-based targets use only their own storage_options; ditto_storage_options is ignored."""
+    """Profile-based targets use only their own storage_options;
+    ditto_storage_options is ignored."""
     pytester.makeconftest("""
         import pytest
         from ditto.backends import BACKEND_REGISTRY
@@ -167,7 +169,8 @@ def test_raises_when_target_and_target_profile_are_both_set(pytester) -> None:
 def test_raises_when_ditto_target_and_ditto_target_profile_are_both_configured(
     pytester,
 ) -> None:
-    """ditto_target and ditto_target_profile in config together raises at configure time."""
+    """ditto_target and ditto_target_profile in config together raises at
+    configure time."""
     pytester.makeini("""
         [pytest]
         ditto_target = memory://x
@@ -239,7 +242,8 @@ def test_raises_when_unknown_profile_name_is_requested(pytester) -> None:
 
 
 def test_raises_when_profile_fixture_dependency_is_missing(pytester) -> None:
-    """A broken ditto_target_profiles fixture dependency fails loudly instead of falling back."""
+    """A broken ditto_target_profiles fixture dependency fails loudly
+    instead of falling back."""
     pytester.makeconftest("""
         import pytest
 
@@ -262,7 +266,8 @@ def test_raises_when_profile_fixture_dependency_is_missing(pytester) -> None:
 
 
 def test_two_profiles_with_same_uri_and_options_share_a_backend(pytester) -> None:
-    """Two profiles that resolve to identical URI and options share one backend instance."""
+    """Two profiles that resolve to identical URI and options share one
+    backend instance."""
     pytester.makeconftest("""
         import pytest
         from ditto.backends import BACKEND_REGISTRY
@@ -309,7 +314,8 @@ def test_two_profiles_with_same_uri_and_options_share_a_backend(pytester) -> Non
 def test_two_profiles_with_same_uri_but_different_options_use_separate_backends(
     pytester,
 ) -> None:
-    """Two profiles with the same URI but different storage_options use distinct backends."""
+    """Two profiles with the same URI but different storage_options use
+    distinct backends."""
     pytester.makeconftest("""
         import pytest
         from ditto.backends import BACKEND_REGISTRY
@@ -353,7 +359,8 @@ def test_two_profiles_with_same_uri_but_different_options_use_separate_backends(
 
 
 def test_profile_with_file_uri_resolves_relative_to_test_file(pytester) -> None:
-    """A profile with a relative file:// URI resolves relative to the test file's directory."""
+    """A profile with a relative file:// URI resolves relative to the test
+    file's directory."""
     pytester.makeconftest("""
         import pytest
 

--- a/tests/ci/test_snapshot_properties.py
+++ b/tests/ci/test_snapshot_properties.py
@@ -54,5 +54,3 @@ def test_unique_keys_never_trigger_duplicate_error(keys: list[str]) -> None:
 
     for i, key in enumerate(keys):
         snapshot(i, key)
-
-


### PR DESCRIPTION
## Summary

Add a dedicated ruff linting job to CI and align pixi lint tasks with pre-commit hooks as the single source of truth.

## Approach

```
CI job → pixi task → pre-commit hook → tool binary
```

This ensures CI and local pre-commit always use identical flags/paths with no duplication to drift.

## Changes

- **.github/workflows/ci.yml**: Add `lint` job running `pixi run -e lint ruff-lint`
- **pyproject.toml**: 
  - Update `typecheck = "pre-commit run basedpyright --all-files"`
  - Add `ruff-lint = "pre-commit run ruff-check --all-files"`
  - Add `include = ["src"]` to `[tool.basedpyright]` to scope correctly when invoked without path args
- **Fix E501 violations**: Wrap 13 pre-existing line-too-long issues in `src/` and `tests/`

## Verification

```
$ pixi run -e lint ruff-lint
All checks passed!

$ pixi run -e lint typecheck
0 errors, 0 warnings, 0 notes
```