### PR TITLE
Lock-file Phase 1 bug fixes (#82–#85)

### DIFF
--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -335,10 +335,14 @@ def cmd_prune(pytest_args):
 def cmd_lock(pytest_args):
     """Rebuild ditto.lock from current snapshots (full run; values unchanged).
 
+    Must run the whole suite: passing positional path/nodeid args narrows the run
+    and is refused, because a narrowed rebuild can truncate entries for files it
+    did not collect. Configure the suite's scope via `testpaths` in pyproject/ini
+    instead.
+
     \b
     Examples:
       ditto lock
-      ditto lock tests/ci/
     """
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "--ditto-lock", *pytest_args],

--- a/src/ditto/plugin.py
+++ b/src/ditto/plugin.py
@@ -35,6 +35,7 @@ from ditto.exceptions import (
     DittoAmbiguousTargetError,
     DittoDuplicateProfileError,
     DittoInvalidProfileError,
+    DittoLockFileError,
     DittoMarkHasNoIOType,
     DittoUnknownProfileError,
 )
@@ -634,20 +635,56 @@ def _append_lockfile(config: pytest.Config) -> None:
         write_lockfile(path, lock)
 
 
+def _fail_session(session: pytest.Session) -> None:
+    """Mark the pytest session as failed without masking a real test failure."""
+    if session.exitstatus == 0:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
+def _xdist_is_distributing(config: pytest.Config) -> bool:
+    """True when pytest-xdist is distributing this run across worker processes.
+
+    Under distribution the controller process (which runs `pytest_sessionfinish`
+    and writes the lock) never executes test bodies, so its `session_tracker` is
+    empty and any lock write would be wrong (see #83). `numprocesses` is set by
+    `-n auto`/`-n N` and is falsy (`None`/`0`) for single-process runs.
+    """
+    return bool(getattr(config.option, "numprocesses", None))
+
+
 def _is_authoritative_run(session: pytest.Session, exitstatus: int) -> bool:
     """True when this run is safe to rebuild the lock file from.
 
-    Refuses filtered runs (`-k`, `-m`, `--lf`/`--ff`), runs with failures, and
-    runs that did not exit cleanly. The `exitstatus` check catches collection
-    errors (a module that fails to import leaves `testsfailed == 0` yet a
-    non-zero exit), which would otherwise let a partial collection rebuild and
-    silently shrink the lock. Node-id / path narrowing is not detected here
-    (documented limitation).
+    Refuses filtered runs (`-k`, `-m`, `--lf`/`--ff`), positional path/nodeid
+    narrowing (`pytest tests/foo.py` or `::nodeid`), runs with failures, and runs
+    that did not exit cleanly. The `exitstatus` check catches collection errors
+    (a module that fails to import leaves `testsfailed == 0` yet a non-zero exit),
+    which would otherwise let a partial collection rebuild and silently shrink the
+    lock.
+
+    Notes
+    -----
+    Positional narrowing is refused outright (#82): a path/nodeid run can silently
+    truncate entries for files it did not collect from a shared target. An
+    alternative considered was *module-scoped preservation* — rewriting only the
+    entries for modules actually exercised this run and preserving the rest, which
+    would make file/dir narrowing safe without refusing. It was rejected because it
+    still cannot make nodeid narrowing safe (that sub-selects within a module) and
+    it stops a full run from ever cleaning entries for deleted files. Refusing is
+    simpler and safe; `ditto lock` with no positional args is the supported full
+    rebuild.
     """
     opt = session.config.option
-    if getattr(opt, "keyword", "") or getattr(opt, "markexpr", ""):
-        return False
-    if getattr(opt, "last_failed", False) or getattr(opt, "failed_first", False):
+    # Any truthy signal here means the run was narrowed or filtered and is not
+    # authoritative over the full keyspace. Add new narrowing options to the tuple.
+    narrowing = (
+        getattr(opt, "keyword", ""),  # -k
+        getattr(opt, "markexpr", ""),  # -m
+        getattr(opt, "last_failed", False),  # --lf
+        getattr(opt, "failed_first", False),  # --ff
+        getattr(opt, "file_or_dir", None),  # positional path/nodeid args
+    )
+    if any(narrowing):
         return False
     return session.testsfailed == 0 and exitstatus == 0
 
@@ -659,7 +696,15 @@ def _rewrite_lockfile(config: pytest.Config) -> None:
     """
     grouped = _grouped(session_tracker.lock_accessed)
     path = config.rootpath / LOCKFILE_NAME
-    existing = read_lockfile(path)
+    # An authoritative rebuild must be able to recover a corrupt lock file, so a
+    # parse failure of the existing file is downgraded to "start fresh" rather
+    # than aborting (see #85). Entries for unexercised targets in a corrupt file
+    # are unrecoverable, which is acceptable for a from-scratch rebuild.
+    try:
+        existing = read_lockfile(path)
+    except DittoLockFileError as exc:
+        warnings.warn(f"Replacing unreadable {LOCKFILE_NAME} ({exc}).", stacklevel=1)
+        existing = None
     targets = dict(existing.targets) if existing is not None else {}
     for (target_id, scheme), entries in grouped.items():
         # A target's scheme is intrinsic to its id; preserve the existing one
@@ -792,20 +837,42 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         "--ditto-introspect", default=""
     ):
         _warn_if_lockfile_ignored(config)
-        try:
-            if config.getoption("--ditto-lock", default=False):
-                if _is_authoritative_run(session, exitstatus):
-                    _rewrite_lockfile(config)
-                else:
-                    warnings.warn(
-                        "--ditto-lock requires a full run (no -k/-m/--lf and no "
-                        "failures); leaving ditto.lock unchanged.",
-                        stacklevel=1,
-                    )
+        is_lock = config.getoption("--ditto-lock", default=False)
+        if _xdist_is_distributing(config):
+            # The controller saw no snapshots under distribution, so it cannot
+            # write the lock correctly (see #83). Refuse an explicit rebuild;
+            # only warn for the passive append path.
+            if is_lock:
+                warnings.warn(
+                    "--ditto-lock cannot rebuild ditto.lock under pytest-xdist "
+                    "distribution; run without -n.",
+                    stacklevel=1,
+                )
+                _fail_session(session)
             else:
-                _append_lockfile(config)
-        except Exception as exc:  # never crash a run over a lock-file write
-            warnings.warn(f"Failed to write {LOCKFILE_NAME}: {exc}", stacklevel=1)
+                warnings.warn(
+                    f"{LOCKFILE_NAME} is not maintained under pytest-xdist "
+                    "distribution (-n); run single-process or `ditto lock` to "
+                    "update it.",
+                    stacklevel=1,
+                )
+        else:
+            try:
+                if is_lock:
+                    if _is_authoritative_run(session, exitstatus):
+                        _rewrite_lockfile(config)
+                    else:
+                        warnings.warn(
+                            "--ditto-lock requires a full run (no -k/-m/--lf, no "
+                            "path/nodeid args, and no failures); leaving "
+                            "ditto.lock unchanged.",
+                            stacklevel=1,
+                        )
+                        _fail_session(session)
+                else:
+                    _append_lockfile(config)
+            except Exception as exc:  # never crash a run over a lock-file write
+                warnings.warn(f"Failed to write {LOCKFILE_NAME}: {exc}", stacklevel=1)
 
     introspect_path = config.getoption("--ditto-introspect", default="")
     if introspect_path:

--- a/tests/ci/test_lockfile_session.py
+++ b/tests/ci/test_lockfile_session.py
@@ -141,8 +141,9 @@ def test_failed_snapshot_write_leaves_no_phantom_lock_entry(pytester):
     """A snapshot whose write fails must not leave an entry in ditto.lock."""
     pytester.makepyfile(test_mod=PHANTOM_MODULE)
 
-    pytester.runpytest_subprocess()  # the snapshot write raises; the test fails
+    result = pytester.runpytest_subprocess()
 
+    assert result.ret != 0  # the write raised, so the scenario actually triggered
     lock = pytester.path / "ditto.lock"
     if lock.exists():
         assert not any("test_phantom" in n for n in _nodeids_in_lockfile(pytester))

--- a/tests/ci/test_lockfile_session.py
+++ b/tests/ci/test_lockfile_session.py
@@ -1,4 +1,7 @@
 import json
+import types
+
+from ditto.plugin import _xdist_is_distributing
 
 pytest_plugins = ["pytester"]
 
@@ -92,8 +95,9 @@ def test_ditto_lock_refuses_to_rebuild_on_filtered_run(pytester):
     pytester.runpytest_subprocess()
     _append_stale_entry(pytester)
 
-    pytester.runpytest_subprocess("--ditto-lock", "-k", "test_alpha")
+    result = pytester.runpytest_subprocess("--ditto-lock", "-k", "test_alpha")
 
+    assert result.ret != 0  # an explicit refusal fails the command
     assert any("test_removed" in n for n in _nodeids_in_lockfile(pytester))
 
 
@@ -127,10 +131,10 @@ def test_warns_when_lockfile_is_gitignored(pytester):
     result.stdout.fnmatch_lines(["*ditto.lock*gitignore*"])
 
 
-PHANTOM_MODULE = '''
+PHANTOM_MODULE = """
 def test_phantom(snapshot):
     snapshot(lambda x: x, key="k")  # unpicklable -> write fails -> test errors
-'''
+"""
 
 
 def test_failed_snapshot_write_leaves_no_phantom_lock_entry(pytester):
@@ -142,3 +146,49 @@ def test_failed_snapshot_write_leaves_no_phantom_lock_entry(pytester):
     lock = pytester.path / "ditto.lock"
     if lock.exists():
         assert not any("test_phantom" in n for n in _nodeids_in_lockfile(pytester))
+
+
+def test_ditto_lock_refuses_path_narrowed_run(pytester):
+    """--ditto-lock with a positional path arg refuses and does not truncate."""
+    pytester.makepyfile(
+        test_a="def test_a(snapshot):\n    assert snapshot(1, key='a') == 1\n",
+        test_b="def test_b(snapshot):\n    assert snapshot(2, key='b') == 2\n",
+    )
+    pytester.runpytest_subprocess()  # full run records both test_a and test_b
+
+    result = pytester.runpytest_subprocess("--ditto-lock", "test_a.py")
+
+    assert result.ret != 0  # path-narrowed rebuild is refused
+    nodeids = _nodeids_in_lockfile(pytester)
+    assert any("test_a" in n for n in nodeids)
+    assert any("test_b" in n for n in nodeids)  # NOT truncated
+
+
+def test_ditto_lock_replaces_corrupt_lock_file(pytester):
+    """--ditto-lock rebuilds a corrupt ditto.lock instead of leaving it broken."""
+    pytester.makepyfile(test_mod=TEST_MODULE)
+    pytester.runpytest_subprocess()  # valid lock with alpha + beta
+    (pytester.path / "ditto.lock").write_text("{not json")  # corrupt it
+
+    result = pytester.runpytest_subprocess("--ditto-lock")
+
+    assert result.ret == 0
+    nodeids = _nodeids_in_lockfile(pytester)  # raises if still corrupt
+    assert any("test_alpha" in n for n in nodeids)
+    assert any("test_beta" in n for n in nodeids)
+
+
+def test_xdist_distribution_detected_when_numprocesses_set():
+    """A positive -n value marks the run as xdist-distributed."""
+    config = types.SimpleNamespace(option=types.SimpleNamespace(numprocesses=4))
+
+    assert _xdist_is_distributing(config) is True
+
+
+def test_no_xdist_distribution_when_numprocesses_absent_or_zero():
+    """No -n (or -n0) is a single-process run."""
+    absent = types.SimpleNamespace(option=types.SimpleNamespace())
+    zero = types.SimpleNamespace(option=types.SimpleNamespace(numprocesses=0))
+
+    assert _xdist_is_distributing(absent) is False
+    assert _xdist_is_distributing(zero) is False


### PR DESCRIPTION
Phase-1 lock-file bug fixes, cherry-picked onto current `main` (Phase 1 itself already landed via #88, so this is just the remaining delta — the bug batch).

Closes #82
Closes #83
Closes #84
Closes #85

## What this fixes

- **#82 — path/nodeid narrowing.** `_is_authoritative_run` now refuses positional path/nodeid args (`config.option.file_or_dir`) instead of truncating entries for un-collected files in a shared target. The `getattr` checks are flattened to a single `any(narrowing)`; the considered alternative (module-scoped preservation) is recorded in a code comment. `ditto lock`'s CLI help is updated to drop the path example.
- **#83 — xdist.** `_xdist_is_distributing` guard: under `-n`, `--ditto-lock` hard-fails (the controller has no observations) and the append path warns it isn't maintained. Detection is unit-tested (xdist is not a dependency, so the distributed-controller branch has no end-to-end test — noted follow-up).
- **#85 — corrupt-lock recovery.** `_rewrite_lockfile` now recovers a corrupt `ditto.lock` by warning and rebuilding from scratch (`existing = None`) rather than aborting.
- **`_fail_session`.** All explicit-command refusals (`--ditto-lock` under `-k`/`-m`, path narrowing, or xdist) now exit non-zero rather than warning-and-exiting-0.
- **#84 — phantom entries.** The core fix (record the lock entry only after a successful write) was already on `main` via #88; this PR strengthens its test to assert the failing run actually failed.

## Validation

- Full `tests/ci` suite green on **py312 and py313** (290 passed, 2 skipped, 2 xfailed).
- New CI gates pass: **ruff-check** and **basedpyright** (0 errors, 0 warnings).

Design tracking: #80. These unblock #79 (Phase 2 / verify).
