### PR TITLE
Lock-file Phase 2: verify + diff engine (#79)

### DIFF
--- a/src/ditto/_reconcile.py
+++ b/src/ditto/_reconcile.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import msgspec
+
+__all__ = ("ReconcileResult", "owned_prefixes", "diff_backend")
+
+
+class ReconcileResult(msgspec.Struct, frozen=True):
+    """Drift between a backend and the lock, scoped to owned prefixes.
+
+    Attributes
+    ----------
+    missing : tuple[str, ...]
+        Storage keys present in the lock but absent from the backend.
+    orphan : tuple[str, ...]
+        Storage keys present in the backend, under an owned prefix, with no lock
+        entry. The caller may further classify these (e.g. created this run vs
+        genuinely stale) for reporting.
+    """
+
+    missing: tuple[str, ...]
+    orphan: tuple[str, ...]
+
+
+def owned_prefixes(modules: set[str], scheme: str) -> frozenset[str]:
+    """Return the storage-key prefixes owned by `modules` for `scheme`.
+
+    File backends use a flat dotted prefix (`module.`); all other schemes use a
+    slash-separated prefix (`module/`). Mirrors the live key derivation.
+    """
+    if scheme == "file":
+        return frozenset(m.replace("/", ".") + "." for m in modules)
+    return frozenset(m + "/" for m in modules)
+
+
+def diff_backend(
+    lock_keys: set[str], backend_keys: set[str], owned: frozenset[str]
+) -> ReconcileResult:
+    """Diff a backend's keys against the lock's keys, scoped to owned prefixes.
+
+    `missing` is every lock key absent from the backend. `orphan` is every
+    backend key that falls under an owned prefix and has no lock entry; backend
+    keys outside the owned prefixes (another suite or branch on a shared backend)
+    are never reported.
+    """
+    missing = tuple(sorted(lock_keys - backend_keys))
+    orphan = tuple(
+        sorted(
+            k
+            for k in backend_keys
+            if k not in lock_keys and any(k.startswith(p) for p in owned)
+        )
+    )
+    return ReconcileResult(missing=missing, orphan=orphan)

--- a/src/ditto/backends/_plugins.py
+++ b/src/ditto/backends/_plugins.py
@@ -4,6 +4,8 @@ import importlib.metadata
 import warnings
 from collections.abc import Callable, MutableMapping
 
+from ..exceptions import DittoWarning
+
 
 __all__ = ("BACKEND_REGISTRY", "load_backends")
 
@@ -28,5 +30,6 @@ def load_backends() -> None:
         except Exception:
             warnings.warn(
                 f"Failed to load ditto backend {ep.name!r}; it will be unavailable.",
+                category=DittoWarning,
                 stacklevel=1,
             )

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -6,6 +6,8 @@ Subcommands
 run         Run pytest, reporting any snapshot activity at the end.
 update      Re-run pytest with --ditto-update to regenerate snapshots.
 prune       Re-run pytest with --ditto-prune to remove stale snapshots.
+lock        Rebuild ditto.lock from current snapshots.
+verify      Fail if the backend has drifted from ditto.lock (read-only).
 list        List all snapshot files under a path.
 clean       Delete all .ditto/ directories under a path.
 status      Show aggregate statistics for snapshots under a path.
@@ -346,6 +348,26 @@ def cmd_lock(pytest_args):
     """
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "--ditto-lock", *pytest_args],
+        check=False,
+    )
+    sys.exit(result.returncode)
+
+
+@cli.command(
+    name="verify",
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+)
+@click.argument("pytest_args", nargs=-1, type=click.UNPROCESSED)
+def cmd_verify(pytest_args):
+    """Fail if the backend has drifted from ditto.lock (read-only).
+
+    \b
+    Examples:
+      ditto verify
+      ditto verify tests/ci/
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--ditto-verify", *pytest_args],
         check=False,
     )
     sys.exit(result.returncode)

--- a/src/ditto/exceptions.py
+++ b/src/ditto/exceptions.py
@@ -1,5 +1,6 @@
 __all__ = (
     "DittoException",
+    "DittoWarning",
     "AdditionalMarkError",
     "DittoMarkHasNoIOType",
     "DuplicateSnapshotKeyError",
@@ -10,6 +11,15 @@ __all__ = (
     "DittoLockFileError",
     "DittoLockFileVersionError",
 )
+
+
+class DittoWarning(UserWarning):
+    """Category for all pytest-ditto advisory warnings.
+
+    Subclasses `UserWarning`, so a blanket `ignore::UserWarning` still applies;
+    use `ignore::ditto.exceptions.DittoWarning` to silence only ditto's
+    advisories, or `error::ditto.exceptions.DittoWarning` to escalate them.
+    """
 
 
 class DittoException(Exception):

--- a/src/ditto/plugin.py
+++ b/src/ditto/plugin.py
@@ -38,6 +38,7 @@ from ditto.exceptions import (
     DittoLockFileError,
     DittoMarkHasNoIOType,
     DittoUnknownProfileError,
+    DittoWarning,
 )
 
 
@@ -703,7 +704,11 @@ def _rewrite_lockfile(config: pytest.Config) -> None:
     try:
         existing = read_lockfile(path)
     except DittoLockFileError as exc:
-        warnings.warn(f"Replacing unreadable {LOCKFILE_NAME} ({exc}).", stacklevel=1)
+        warnings.warn(
+            f"Replacing unreadable {LOCKFILE_NAME} ({exc}).",
+            category=DittoWarning,
+            stacklevel=1,
+        )
         existing = None
     targets = dict(existing.targets) if existing is not None else {}
     for (target_id, scheme), entries in grouped.items():
@@ -736,6 +741,7 @@ def _warn_if_lockfile_ignored(config: pytest.Config) -> None:
         warnings.warn(
             f"{LOCKFILE_NAME} matches a .gitignore pattern but must be committed "
             "to do its job; remove the ignore rule.",
+            category=DittoWarning,
             stacklevel=1,
         )
 
@@ -813,6 +819,7 @@ def _enumerate_entries(backend: MutableMapping[str, bytes]) -> list[ManifestEntr
         warnings.warn(
             f"Failed to enumerate backend {backend!r}: {exc}; "
             "reporting it with no entries.",
+            category=DittoWarning,
             stacklevel=1,
         )
         return []
@@ -846,6 +853,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                 warnings.warn(
                     "--ditto-lock cannot rebuild ditto.lock under pytest-xdist "
                     "distribution; run without -n.",
+                    category=DittoWarning,
                     stacklevel=1,
                 )
                 _fail_session(session)
@@ -854,6 +862,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                     f"{LOCKFILE_NAME} is not maintained under pytest-xdist "
                     "distribution (-n); run single-process or `ditto lock` to "
                     "update it.",
+                    category=DittoWarning,
                     stacklevel=1,
                 )
         else:
@@ -866,13 +875,18 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                             "--ditto-lock requires a full run (no -k/-m/--lf, no "
                             "path/nodeid args, and no failures); leaving "
                             "ditto.lock unchanged.",
+                            category=DittoWarning,
                             stacklevel=1,
                         )
                         _fail_session(session)
                 else:
                     _append_lockfile(config)
             except Exception as exc:  # never crash a run over a lock-file write
-                warnings.warn(f"Failed to write {LOCKFILE_NAME}: {exc}", stacklevel=1)
+                warnings.warn(
+                    f"Failed to write {LOCKFILE_NAME}: {exc}",
+                    category=DittoWarning,
+                    stacklevel=1,
+                )
 
     introspect_path = config.getoption("--ditto-introspect", default="")
     if introspect_path:
@@ -917,6 +931,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             warnings.warn(
                 f"Backend {record.backend!r} does not support enumeration; "
                 "skipping unused-snapshot detection for this backend.",
+                category=DittoWarning,
                 stacklevel=1,
             )
             continue
@@ -928,6 +943,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                 f"Backend {record.backend!r} raised {type(exc).__name__} during "
                 f"enumeration: {exc}; skipping unused-snapshot "
                 "detection for this backend.",
+                category=DittoWarning,
                 stacklevel=1,
             )
             continue
@@ -949,6 +965,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                 except Exception as exc:
                     warnings.warn(
                         f"Failed to prune snapshot {raw_key!r}: {exc}",
+                        category=DittoWarning,
                         stacklevel=1,
                     )
                 else:
@@ -992,6 +1009,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                 warnings.warn(
                     f"Failed to enumerate ghost directory {ditto_dir!r}: {exc}; "
                     "skipping unused-snapshot detection for this directory.",
+                    category=DittoWarning,
                     stacklevel=1,
                 )
                 continue
@@ -1004,6 +1022,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
                     except Exception as exc:
                         warnings.warn(
                             f"Failed to prune snapshot {raw_key!r}: {exc}",
+                            category=DittoWarning,
                             stacklevel=1,
                         )
                     else:

--- a/src/ditto/plugin.py
+++ b/src/ditto/plugin.py
@@ -837,6 +837,16 @@ def _run_verify(session: pytest.Session) -> None:
             storage_key(LockEntry(seen.nodeid, seen.key, seen.recorder), seen.scheme)
         )
 
+    opt = session.config.option
+    is_partial = bool(getattr(opt, "keyword", "") or getattr(opt, "markexpr", ""))
+    if is_partial:
+        warnings.warn(
+            "ditto verify ran on a partial selection; only exercised targets "
+            "were checked (partial verification).",
+            category=DittoWarning,
+            stacklevel=1,
+        )
+
     all_missing: list[str] = []
     all_orphan: list[str] = []
     all_unsynced: list[str] = []

--- a/src/ditto/plugin.py
+++ b/src/ditto/plugin.py
@@ -525,6 +525,9 @@ def snapshot(request: pytest.FixtureRequest) -> Snapshot:
     backend, abs_uri = _resolve_target(mark_target, mark_profile, request)
 
     session_tracker.register_backend_module(id(backend), module)
+    session_tracker.register_target_backend(
+        portable_target_id(abs_uri, rootdir), urlparse(abs_uri).scheme, backend
+    )
 
     if request.config.getoption("--ditto-introspect", default=""):
         _introspect_backends.setdefault(abs_uri, backend)

--- a/src/ditto/plugin.py
+++ b/src/ditto/plugin.py
@@ -23,11 +23,14 @@ from ditto._lockfile import (
     LockTarget,
     LOCKFILE_NAME,
     LOCKFILE_VERSION,
+    _split_nodeid,
     merge_append,
     portable_target_id,
     read_lockfile,
+    storage_key,
     write_lockfile,
 )
+from ditto._reconcile import diff_backend, owned_prefixes
 from ditto._report import render_session_report
 from ditto.recorders import Recorder, RECORDER_REGISTRY, default as _default_recorder
 from ditto.exceptions import (
@@ -520,6 +523,7 @@ def snapshot(request: pytest.FixtureRequest) -> Snapshot:
     marks = list(request.node.iter_markers(name="record"))
     recorder = _resolve_recorder(marks)
     update: bool = request.config.getoption("--ditto-update", default=False)  # type: ignore[assignment]
+    readonly: bool = request.config.getoption("--ditto-verify", default=False)  # type: ignore[assignment]
 
     mark_target, mark_profile = _parse_mark_target_selection(marks)
     backend, abs_uri = _resolve_target(mark_target, mark_profile, request)
@@ -543,6 +547,7 @@ def snapshot(request: pytest.FixtureRequest) -> Snapshot:
         _backend=backend,
         recorder=recorder,
         update=update,
+        readonly=readonly,
         nodeid=request.node.nodeid,
         target_id=portable_target_id(abs_uri, rootdir),
     )
@@ -584,6 +589,15 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help=(
             "Rebuild ditto.lock from the snapshots exercised by this run, without "
             "rewriting snapshot values. Requires a full (unfiltered, passing) run."
+        ),
+    )
+    group.addoption(
+        "--ditto-verify",
+        action="store_true",
+        default=False,
+        help=(
+            "Read-only: fail the run if the live backend has drifted from "
+            "ditto.lock (missing, orphan, or unrecorded snapshots)."
         ),
     )
     parser.addini(
@@ -749,6 +763,106 @@ def _warn_if_lockfile_ignored(config: pytest.Config) -> None:
         )
 
 
+def _verify_target(
+    target_id: str,
+    scheme: str,
+    backend: MutableMapping[str, bytes],
+    lock: LockFile | None,
+    session_modules: set[str],
+    created_keys: set[str],
+) -> tuple[list[str], list[str], list[str]]:
+    """Return (missing, orphan, unsynced) storage keys for one target.
+
+    `unsynced` is every key produced this run that the lock does not record
+    (whether or not it reached the backend — read-only verify blocks the write,
+    so an intended new snapshot never lands on the backend). `orphan` is a backend
+    key, absent from the lock, that was not produced this run (e.g. a deleted
+    test's leftover). `missing` is a lock key absent from the backend.
+    """
+    lock_target = lock.targets.get(target_id) if lock is not None else None
+    entries = lock_target.entries if lock_target is not None else ()
+    lock_keys = {storage_key(e, scheme) for e in entries}
+    lock_modules = {_split_nodeid(e.nodeid)[0] for e in entries}
+    owned = owned_prefixes(session_modules | lock_modules, scheme)
+    result = diff_backend(lock_keys, set(backend), owned)
+    # Orphans produced this run: in backend but not in lock, and created this run.
+    # Also catch intended creates that were blocked by read-only mode and never
+    # reached the backend (created this run, not in lock, not on backend).
+    unsynced_set = created_keys - lock_keys
+    unsynced = sorted(unsynced_set)
+    orphan = [k for k in result.orphan if k not in unsynced_set]
+    return list(result.missing), orphan, unsynced
+
+
+def _verify_report_error(message: str) -> None:
+    print(f"ditto verify: {message}")
+
+
+def _verify_report_drift(
+    missing: list[str], orphan: list[str], unsynced: list[str]
+) -> None:
+    print("ditto verify: lock drift detected")
+    for k in sorted(missing):
+        print(f"  missing (recorded in lock, absent from backend): {k}")
+    for k in sorted(orphan):
+        print(f"  orphan (in backend, not in lock): {k}")
+    for k in sorted(unsynced):
+        print(f"  unsynced (produced this run, not in lock — run `ditto lock`): {k}")
+
+
+def _run_verify(session: pytest.Session) -> None:
+    """Verify every exercised target against ditto.lock; fail the session on drift."""
+    config = session.config
+    try:
+        lock = read_lockfile(config.rootpath / LOCKFILE_NAME)
+    except DittoLockFileError as exc:
+        _verify_report_error(str(exc))
+        _fail_session(session)
+        return
+    if lock is None:
+        _verify_report_error(
+            f"no {LOCKFILE_NAME} to verify against; run `ditto lock` to create one."
+        )
+        _fail_session(session)
+        return
+
+    modules_by_target: dict[str, set[str]] = {}
+    created_by_target: dict[str, set[str]] = {}
+    for seen in session_tracker.lock_accessed:
+        modules_by_target.setdefault(seen.target_id, set()).add(
+            _split_nodeid(seen.nodeid)[0]
+        )
+    for seen in session_tracker.lock_created:
+        created_by_target.setdefault(seen.target_id, set()).add(
+            storage_key(LockEntry(seen.nodeid, seen.key, seen.recorder), seen.scheme)
+        )
+
+    all_missing: list[str] = []
+    all_orphan: list[str] = []
+    all_unsynced: list[str] = []
+    for target_id, (scheme, backend) in session_tracker.target_backends.items():
+        try:
+            missing, orphan, unsynced = _verify_target(
+                target_id,
+                scheme,
+                backend,
+                lock,
+                modules_by_target.get(target_id, set()),
+                created_by_target.get(target_id, set()),
+            )
+        except Exception as exc:  # backend unreachable, etc.
+            _verify_report_error(f"could not verify {target_id!r}: {exc}")
+            _fail_session(session)
+            continue
+        all_missing.extend(missing)
+        all_orphan.extend(orphan)
+        all_unsynced.extend(unsynced)
+
+    if all_missing or all_orphan or all_unsynced:
+        _verify_report_drift(all_missing, all_orphan, all_unsynced)
+        _fail_session(session)
+
+
 def _validate_target_config(config: pytest.Config) -> None:
     """Raise if both ditto_target and ditto_target_profile are configured."""
     if config.getini("ditto_target") and config.getini("ditto_target_profile"):
@@ -762,6 +876,14 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "record(recorder): snapshot with a specific recorder",
     )
+    if config.getoption("--ditto-verify", default=False) and (
+        config.getoption("--ditto-update", default=False)
+        or config.getoption("--ditto-lock", default=False)
+    ):
+        raise pytest.UsageError(
+            "--ditto-verify is read-only and cannot be combined with "
+            "--ditto-update or --ditto-lock."
+        )
     try:
         _validate_target_config(config)
     except DittoAmbiguousTargetError as exc:
@@ -846,6 +968,9 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     if not _is_xdist_worker(config) and not config.getoption(
         "--ditto-introspect", default=""
     ):
+        if config.getoption("--ditto-verify", default=False):
+            _run_verify(session)
+            return
         _warn_if_lockfile_ignored(config)
         is_lock = config.getoption("--ditto-lock", default=False)
         if _xdist_is_distributing(config):

--- a/src/ditto/plugin.py
+++ b/src/ditto/plugin.py
@@ -889,10 +889,11 @@ def pytest_configure(config: pytest.Config) -> None:
     if config.getoption("--ditto-verify", default=False) and (
         config.getoption("--ditto-update", default=False)
         or config.getoption("--ditto-lock", default=False)
+        or config.getoption("--ditto-prune", default=False)
     ):
         raise pytest.UsageError(
             "--ditto-verify is read-only and cannot be combined with "
-            "--ditto-update or --ditto-lock."
+            "--ditto-update, --ditto-lock, or --ditto-prune."
         )
     try:
         _validate_target_config(config)

--- a/src/ditto/recorders/_plugins.py
+++ b/src/ditto/recorders/_plugins.py
@@ -2,6 +2,7 @@ import importlib.metadata
 import warnings
 
 from ._protocol import Recorder
+from ..exceptions import DittoWarning
 
 
 __all__ = ("RECORDER_REGISTRY", "MARK_REGISTRY", "load_recorders", "load_mark_plugins")
@@ -28,6 +29,7 @@ def load_recorders() -> dict[str, Recorder]:
         except Exception as exc:
             warnings.warn(
                 f"ditto: failed to load recorder {ep.name!r}: {exc}",
+                category=DittoWarning,
                 stacklevel=2,
             )
     return result
@@ -54,6 +56,7 @@ def load_mark_plugins() -> dict[str, object]:
         except Exception as exc:
             warnings.warn(
                 f"ditto: failed to load mark plugin {ep.name!r}: {exc}",
+                category=DittoWarning,
                 stacklevel=2,
             )
     return result

--- a/src/ditto/snapshot.py
+++ b/src/ditto/snapshot.py
@@ -114,6 +114,11 @@ class _SessionTracker:
     backend_modules: dict[int, set[str]] = field(default_factory=dict)
     lock_created: set[LockSeen] = field(default_factory=set)
     lock_accessed: set[LockSeen] = field(default_factory=set)
+    # Maps portable target_id → (scheme, live backend); populated at fixture
+    # creation so verify (and prune) can enumerate every active target's backend.
+    target_backends: dict[str, tuple[str, MutableMapping[str, bytes]]] = field(
+        default_factory=dict
+    )
 
     def register_backend_module(self, backend_id: int, module: str) -> None:
         """Record that `module` uses the backend identified by `backend_id`.
@@ -134,6 +139,12 @@ class _SessionTracker:
             self._records[backend_id] = _BackendRecord(backend=backend, key_of=key_of)
         self._records[backend_id].accessed.add(key)
 
+    def register_target_backend(
+        self, target_id: str, scheme: str, backend: MutableMapping[str, bytes]
+    ) -> None:
+        """Record the live backend (and scheme) resolved for `target_id`."""
+        self.target_backends[target_id] = (scheme, backend)
+
     def record_lock_seen(self, seen: LockSeen, *, created: bool) -> None:
         """Record a lock entry accessed this session; also as created on first write."""
         self.lock_accessed.add(seen)
@@ -148,6 +159,7 @@ class _SessionTracker:
         self.backend_modules.clear()
         self.lock_created.clear()
         self.lock_accessed.clear()
+        self.target_backends.clear()
 
     @property
     def records(self) -> dict[int, _BackendRecord]:

--- a/src/ditto/snapshot.py
+++ b/src/ditto/snapshot.py
@@ -219,6 +219,10 @@ class Snapshot:
         Serialisation strategy. Defaults to pickle.
     update : bool
         When True, overwrite existing snapshots. Set by `--ditto-update`.
+    readonly : bool
+        When True, never write to the backend — `resolve_snapshot` returns the
+        stored value (or the given data, if absent) without persisting. Set by
+        `--ditto-verify` so a verify run cannot recreate a deleted snapshot.
     nodeid : str
         Full pytest node id for the owning test, e.g. `tests/test_api.py::test_foo`.
         Used to build lock-file entries. Empty when constructed outside the fixture.
@@ -232,6 +236,7 @@ class Snapshot:
     _backend: MutableMapping[str, bytes] = field(repr=False, compare=False, hash=False)
     recorder: Recorder = field(default_factory=_default_recorder)
     update: bool = False
+    readonly: bool = False
     nodeid: str = ""
     target_id: str = ""
 
@@ -330,6 +335,19 @@ def resolve_snapshot(snapshot: Snapshot, data: Any, key: str) -> Any:
         if snapshot.target_id
         else None
     )
+
+    if snapshot.readonly:
+        # In read-only mode (e.g. --ditto-verify) never write to the backend.
+        # Return the existing value if present, otherwise return `data` unchanged
+        # so the test assertion can still pass, but leave the backend untouched so
+        # the drift check can detect the missing key.
+        # Record as "created" when the key is absent so that the verify hook can
+        # identify intended-but-blocked new snapshots as unsynced.
+        if seen is not None:
+            session_tracker.record_lock_seen(seen, created=not exists)
+        if exists:
+            return store[storage_key]
+        return data
 
     if not exists or snapshot.update:
         store[storage_key] = data

--- a/tests/ci/test_reconcile.py
+++ b/tests/ci/test_reconcile.py
@@ -1,4 +1,10 @@
+import fsspec
+
 from ditto._reconcile import ReconcileResult, owned_prefixes, diff_backend
+from ditto._lockfile import LockEntry, storage_key
+from ditto.snapshot import Snapshot, resolve_snapshot, session_tracker
+from ditto.backends import FsspecMapping
+from ditto.recorders import default as _default_recorder
 
 
 def test_owned_prefixes_are_dotted_for_file_scheme():
@@ -56,7 +62,9 @@ def test_ignores_backend_keys_outside_owned_prefixes():
 def test_reports_nothing_when_backend_matches_lock():
     """No drift when the backend's owned keys equal the lock's keys."""
     keys = {"tests.m.test_a@k.pkl"}
-    result = diff_backend(lock_keys=keys, backend_keys=keys, owned=frozenset({"tests.m."}))
+    result = diff_backend(
+        lock_keys=keys, backend_keys=keys, owned=frozenset({"tests.m."})
+    )
 
     assert result == ReconcileResult(missing=(), orphan=())
 
@@ -65,7 +73,11 @@ def test_classifies_orphans_across_multiple_owned_prefixes():
     """Orphan detection honours every owned prefix, not just the first."""
     result = diff_backend(
         lock_keys=set(),
-        backend_keys={"tests.a.test_x@k.pkl", "tests.b.test_y@k.pkl", "other.z@k.pkl"},
+        backend_keys={
+            "tests.a.test_x@k.pkl",
+            "tests.b.test_y@k.pkl",
+            "other.z@k.pkl",
+        },
         owned=frozenset({"tests.a.", "tests.b."}),
     )
 
@@ -83,3 +95,28 @@ def test_key_in_both_lock_and_backend_is_not_an_orphan():
 
     assert result.orphan == ("tests.m.test_b@k.pkl",)
     assert result.missing == ()
+
+
+def test_storage_key_matches_the_key_the_fixture_actually_stores(tmp_path):
+    """storage_key(nodeid) equals the backend key a real resolve_snapshot writes."""
+    session_tracker.reset()
+    root = (tmp_path / ".ditto").as_posix()
+    backend = FsspecMapping(fsspec.filesystem("file"), root)
+    snap = Snapshot(
+        group_name="TestX.test_foo",
+        module="tests/test_api",
+        target=f"file://{tmp_path}/.ditto",
+        _backend=backend,
+        recorder=_default_recorder(),
+        nodeid="tests/test_api.py::TestX::test_foo",
+        target_id="tests/.ditto",
+    )
+    resolve_snapshot(snap, 123, "k")  # writes the snapshot to the backend
+
+    stored_keys = set(backend)  # the actual storage keys on the backend
+    derived = storage_key(
+        LockEntry("tests/test_api.py::TestX::test_foo", "k", "pkl"), "file"
+    )
+
+    assert derived in stored_keys
+    session_tracker.reset()

--- a/tests/ci/test_reconcile.py
+++ b/tests/ci/test_reconcile.py
@@ -1,0 +1,85 @@
+from ditto._reconcile import ReconcileResult, owned_prefixes, diff_backend
+
+
+def test_owned_prefixes_are_dotted_for_file_scheme():
+    """File backends own flat dotted prefixes."""
+    actual = owned_prefixes({"tests/test_api"}, "file")
+
+    expected = frozenset({"tests.test_api."})
+    assert actual == expected
+
+
+def test_owned_prefixes_are_slash_separated_for_remote_scheme():
+    """Remote backends own slash-separated prefixes."""
+    actual = owned_prefixes({"tests/test_api"}, "s3")
+
+    expected = frozenset({"tests/test_api/"})
+    assert actual == expected
+
+
+def test_reports_missing_when_lock_key_absent_from_backend():
+    """A key in the lock but not the backend is missing."""
+    result = diff_backend(
+        lock_keys={"tests.m.test_a@k.pkl"},
+        backend_keys=set(),
+        owned=frozenset({"tests.m."}),
+    )
+
+    assert result.missing == ("tests.m.test_a@k.pkl",)
+    assert result.orphan == ()
+
+
+def test_reports_orphan_when_backend_key_under_owned_prefix_absent_from_lock():
+    """A backend key under an owned prefix with no lock entry is an orphan."""
+    result = diff_backend(
+        lock_keys=set(),
+        backend_keys={"tests.m.test_a@k.pkl"},
+        owned=frozenset({"tests.m."}),
+    )
+
+    assert result.orphan == ("tests.m.test_a@k.pkl",)
+    assert result.missing == ()
+
+
+def test_ignores_backend_keys_outside_owned_prefixes():
+    """Keys from another suite/branch on a shared backend are never orphans."""
+    result = diff_backend(
+        lock_keys=set(),
+        backend_keys={"other.suite.test_z@k.pkl"},
+        owned=frozenset({"tests.m."}),
+    )
+
+    assert result.orphan == ()
+    assert result.missing == ()
+
+
+def test_reports_nothing_when_backend_matches_lock():
+    """No drift when the backend's owned keys equal the lock's keys."""
+    keys = {"tests.m.test_a@k.pkl"}
+    result = diff_backend(lock_keys=keys, backend_keys=keys, owned=frozenset({"tests.m."}))
+
+    assert result == ReconcileResult(missing=(), orphan=())
+
+
+def test_classifies_orphans_across_multiple_owned_prefixes():
+    """Orphan detection honours every owned prefix, not just the first."""
+    result = diff_backend(
+        lock_keys=set(),
+        backend_keys={"tests.a.test_x@k.pkl", "tests.b.test_y@k.pkl", "other.z@k.pkl"},
+        owned=frozenset({"tests.a.", "tests.b."}),
+    )
+
+    assert result.orphan == ("tests.a.test_x@k.pkl", "tests.b.test_y@k.pkl")
+
+
+def test_key_in_both_lock_and_backend_is_not_an_orphan():
+    """A key present in both the lock and the backend is never an orphan."""
+    keys = {"tests.m.test_a@k.pkl"}
+    result = diff_backend(
+        lock_keys=keys,
+        backend_keys=keys | {"tests.m.test_b@k.pkl"},
+        owned=frozenset({"tests.m."}),
+    )
+
+    assert result.orphan == ("tests.m.test_b@k.pkl",)
+    assert result.missing == ()

--- a/tests/ci/test_verify_session.py
+++ b/tests/ci/test_verify_session.py
@@ -129,3 +129,25 @@ def test_verify_cannot_combine_with_update(pytester):
 
     assert result.ret != 0
     result.stderr.fnmatch_lines(["*read-only*"])
+
+
+def test_verify_fails_when_no_lockfile_exists(pytester):
+    """Verifying with no ditto.lock is an error, not a silent pass."""
+    pytester.makepyfile(test_mod=VERIFY_MODULE)
+    # no prior run, so no ditto.lock
+
+    result = pytester.runpytest_subprocess("--ditto-verify")
+
+    assert result.ret != 0
+    result.stdout.fnmatch_lines(["*no ditto.lock*"])
+
+
+def test_verify_partial_run_warns_but_passes_when_clean(pytester):
+    """A clean partial verify passes but warns it was partial."""
+    _seed_lock(pytester)
+
+    result = pytester.runpytest_subprocess("--ditto-verify", "-k", "test_alpha")
+
+    assert result.ret == 0
+    # Match the warning text specifically (not the temp-dir name in the header).
+    result.stdout.fnmatch_lines(["*partial verification*"])

--- a/tests/ci/test_verify_session.py
+++ b/tests/ci/test_verify_session.py
@@ -1,8 +1,11 @@
+import json
 import types
 
 from ditto.exceptions import DittoWarning
 from ditto.plugin import _warn_if_lockfile_ignored
 from ditto.snapshot import _SessionTracker
+
+pytest_plugins = ["pytester"]
 
 
 def test_ditto_warning_is_a_user_warning():
@@ -37,3 +40,92 @@ def test_tracker_reset_clears_target_backends():
     tracker.reset()
 
     assert tracker.target_backends == {}
+
+
+VERIFY_MODULE = '''
+def test_alpha(snapshot):
+    assert snapshot(1, key="a") == 1
+
+def test_beta(snapshot):
+    assert snapshot(2, key="b") == 2
+'''
+
+
+def _seed_lock(pytester):
+    """Run once to create snapshots + ditto.lock, returning the lock path."""
+    pytester.makepyfile(test_mod=VERIFY_MODULE)
+    pytester.runpytest_subprocess()
+    return pytester.path / "ditto.lock"
+
+
+def test_verify_passes_when_backend_matches_lock(pytester):
+    """A clean committed lock + matching snapshots verifies green."""
+    _seed_lock(pytester)
+
+    result = pytester.runpytest_subprocess("--ditto-verify")
+
+    assert result.ret == 0
+
+
+def test_verify_fails_when_a_snapshot_is_missing(pytester):
+    """A lock entry whose snapshot file is gone fails verify."""
+    _seed_lock(pytester)
+    snap_dir = pytester.path / ".ditto"
+    next(p for p in snap_dir.iterdir() if "test_alpha" in p.name).unlink()
+
+    result = pytester.runpytest_subprocess("--ditto-verify")
+
+    assert result.ret != 0
+
+
+def test_verify_fails_on_orphan_backend_snapshot(pytester):
+    """A backend snapshot with no lock entry fails verify."""
+    lock_path = _seed_lock(pytester)
+    data = json.loads(lock_path.read_text())
+    target = next(iter(data["targets"].values()))
+    target["entries"] = [e for e in target["entries"] if "test_beta" not in e["nodeid"]]
+    lock_path.write_text(json.dumps(data))  # beta now an orphan on the backend
+
+    result = pytester.runpytest_subprocess("--ditto-verify")
+
+    assert result.ret != 0
+
+
+def test_verify_fails_when_a_test_produces_an_unrecorded_snapshot(pytester):
+    """A new key not in the committed lock (unsynced) fails verify."""
+    _seed_lock(pytester)
+    pytester.makepyfile(
+        test_mod=VERIFY_MODULE
+        + '''
+def test_gamma(snapshot):
+    assert snapshot(3, key="c") == 3
+'''
+    )
+
+    result = pytester.runpytest_subprocess("--ditto-verify")
+
+    assert result.ret != 0
+
+
+def test_verify_is_read_only_and_does_not_recreate_a_deleted_snapshot(pytester):
+    """Read-only verify must not rewrite the deleted snapshot or the lock."""
+    lock_path = _seed_lock(pytester)
+    lock_before = lock_path.read_bytes()
+    snap_dir = pytester.path / ".ditto"
+    deleted = next(p for p in snap_dir.iterdir() if "test_alpha" in p.name)
+    deleted.unlink()
+
+    pytester.runpytest_subprocess("--ditto-verify")
+
+    assert not deleted.exists()  # verify did not recreate the snapshot
+    assert lock_path.read_bytes() == lock_before  # lock left untouched
+
+
+def test_verify_cannot_combine_with_update(pytester):
+    """--ditto-verify (read-only) is rejected alongside a write flag."""
+    pytester.makepyfile(test_mod=VERIFY_MODULE)
+
+    result = pytester.runpytest_subprocess("--ditto-verify", "--ditto-update")
+
+    assert result.ret != 0
+    result.stderr.fnmatch_lines(["*read-only*"])

--- a/tests/ci/test_verify_session.py
+++ b/tests/ci/test_verify_session.py
@@ -2,6 +2,7 @@ import types
 
 from ditto.exceptions import DittoWarning
 from ditto.plugin import _warn_if_lockfile_ignored
+from ditto.snapshot import _SessionTracker
 
 
 def test_ditto_warning_is_a_user_warning():
@@ -16,3 +17,23 @@ def test_gitignore_guard_warns_with_ditto_category(tmp_path, recwarn):
     _warn_if_lockfile_ignored(types.SimpleNamespace(rootpath=tmp_path))
 
     assert any(issubclass(w.category, DittoWarning) for w in recwarn.list)
+
+
+def test_tracker_registers_target_backend():
+    """A target id maps to its (scheme, backend) for later enumeration."""
+    tracker = _SessionTracker()
+    backend = object()
+
+    tracker.register_target_backend("tests/.ditto", "file", backend)
+
+    assert tracker.target_backends["tests/.ditto"] == ("file", backend)
+
+
+def test_tracker_reset_clears_target_backends():
+    """Reset drops registered target backends."""
+    tracker = _SessionTracker()
+    tracker.register_target_backend("tests/.ditto", "file", object())
+
+    tracker.reset()
+
+    assert tracker.target_backends == {}

--- a/tests/ci/test_verify_session.py
+++ b/tests/ci/test_verify_session.py
@@ -1,0 +1,18 @@
+import types
+
+from ditto.exceptions import DittoWarning
+from ditto.plugin import _warn_if_lockfile_ignored
+
+
+def test_ditto_warning_is_a_user_warning():
+    """DittoWarning subclasses UserWarning so existing filters still apply."""
+    assert issubclass(DittoWarning, UserWarning)
+
+
+def test_gitignore_guard_warns_with_ditto_category(tmp_path, recwarn):
+    """The .gitignore guard emits its advisory under the DittoWarning category."""
+    (tmp_path / ".gitignore").write_text("ditto.lock\n")
+
+    _warn_if_lockfile_ignored(types.SimpleNamespace(rootpath=tmp_path))
+
+    assert any(issubclass(w.category, DittoWarning) for w in recwarn.list)

--- a/tests/ci/test_verify_session.py
+++ b/tests/ci/test_verify_session.py
@@ -1,5 +1,9 @@
 import json
+import shutil
+import subprocess
 import types
+
+import pytest
 
 from ditto.exceptions import DittoWarning
 from ditto.plugin import _warn_if_lockfile_ignored
@@ -151,3 +155,18 @@ def test_verify_partial_run_warns_but_passes_when_clean(pytester):
     assert result.ret == 0
     # Match the warning text specifically (not the temp-dir name in the header).
     result.stdout.fnmatch_lines(["*partial verification*"])
+
+
+def test_ditto_verify_cli_fails_on_drift(pytester, monkeypatch):
+    """`ditto verify` shells out to pytest --ditto-verify and propagates failure."""
+    if shutil.which("ditto") is None:
+        pytest.skip("ditto console script not on PATH in this environment")
+    _seed_lock(pytester)
+    snap_dir = pytester.path / ".ditto"
+    next(p for p in snap_dir.iterdir() if "test_alpha" in p.name).unlink()
+
+    monkeypatch.chdir(pytester.path)
+    result = subprocess.run(["ditto", "verify"], capture_output=True)
+
+    assert result.returncode != 0
+    assert b"drift" in result.stdout  # a verify-specific failure, not a generic error


### PR DESCRIPTION
## Phase 2: verify + diff engine

**Full design:** #80 · **Closes #79.** Builds on Phase 1 (`ditto.lock`) + the #82–#85 bug batch, both on `main`.

Adds a read-only CI guard — `--ditto-verify` / `ditto verify` — that fails a run when the live backend has drifted from the committed `ditto.lock`, on a pure shared diff engine that Phase 3 (prune) will reuse.

### What shipped

- **`src/ditto/_reconcile.py` (new):** pure `diff_backend(lock_keys, backend_keys, owned) -> ReconcileResult(missing, orphan)` + `owned_prefixes(modules, scheme)`. No I/O; owned-prefix scoping ignores other suites'/branches' keys on shared backends.
- **`src/ditto/exceptions.py`:** `DittoWarning(UserWarning)` — every `warnings.warn` in ditto (across `plugin.py` and the recorder/backend plugin loaders) now carries `category=DittoWarning`, so advisories can be silenced/escalated independently. Load-bearing signals (verify drift, refusals) are hard failures, not warnings.
- **`src/ditto/snapshot.py`:** `_SessionTracker.target_backends` (target_id → live backend) for verify enumeration; a `Snapshot.readonly` mode (see below).
- **`src/ditto/plugin.py`:** `--ditto-verify` option; `_run_verify`/`_verify_target` + report; at session finish, diffs each exercised target and `_fail_session`s on **missing** (in lock, gone from backend), **orphan** (in backend, not in lock), or **unsynced** (produced this run, not in lock). No-lock and corrupt-lock fail loudly; a partial (`-k`/`-m`) run warns it only checked exercised targets. A `pytest_configure` guard rejects `--ditto-verify` with any write flag (`--ditto-update`/`--ditto-lock`/`--ditto-prune`).
- **`src/ditto/cli.py`:** `ditto verify` (shells out to `pytest --ditto-verify`).

### Design note: read-only mode

Verify runs *after* the tests execute. Without suppressing writes, a test would silently **recreate** a deleted snapshot before the check, making "missing" detection falsely green. So `--ditto-verify` puts snapshots in `readonly` mode (`resolve_snapshot` records observations but never writes). A test asserts the read-only guarantee directly (deleted snapshot stays absent; lock untouched).

### Validation

- Full `tests/ci` suite green on **py312 and py313** (312 passed, 2 skipped, 2 xfailed each); **ruff-check** and **basedpyright** CI gates clean.
- Each task went through implementer + spec + code-quality review; the read-only addition (beyond the original plan) was independently validated as required, correct, and minimal.

### Deferred follow-ups

- Move `_verify_target`'s drift-classification into `_reconcile.py` when Phase 3's prune co-consumes it (so the shared interface is designed for both).
- xdist: verify is single-process only (inherits the library's existing limitation, #83); no distributed integration test (xdist isn't a dependency).
