### PR TITLE
Lock-file Phase 4: credential-free CLI inventory (#77)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
     - Custom Recorders: guides/custom-recorders.md
     - Storage Backends: guides/backends.md
     - Custom Backends: guides/custom-backends.md
+    - The Lock File: guides/lock-file.md
     - unittest Support: guides/unittest.md
     - Upgrading: guides/upgrading.md
   - CLI Reference:
@@ -45,6 +46,7 @@ nav:
     - ditto run: cli/run.md
     - ditto update: cli/update.md
     - ditto prune: cli/prune.md
+    - ditto verify: cli/verify.md
     - ditto list: cli/list.md
     - ditto status: cli/status.md
     - ditto clean: cli/clean.md

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -9,6 +9,7 @@ The `ditto` command provides snapshot management tools independent of a test run
 | [`ditto run`](run.md) | Run pytest with snapshot reporting |
 | [`ditto update`](update.md) | Regenerate all snapshots |
 | [`ditto prune`](prune.md) | Remove stale snapshots |
+| [`ditto verify`](verify.md) | Fail if the backend drifted from `ditto.lock` |
 | [`ditto list`](list.md) | List all snapshot files |
 | [`ditto status`](status.md) | Show aggregate statistics |
 | [`ditto clean`](clean.md) | Delete all `.ditto/` directories |
@@ -17,20 +18,19 @@ The `ditto` command provides snapshot management tools independent of a test run
 | [`ditto lint`](lint.md) | Check snapshots for issues |
 | [`ditto stats`](stats.md) | Per-directory usage breakdown |
 
-## CLI and Remote Backends
+## CLI and remote backends
 
-`ditto list`, `status`, `stats`, and `lint` work with remote and registered
-backends, not just local `file://` snapshots.
+`ditto list`, `status`, `stats`, and `lint` are **credential-free by default**.
+Local snapshots are read straight from the filesystem; remote snapshots are read
+from the committed `ditto.lock`. No test modules are imported and no backend
+credentials are needed — even for projects with remote or fixture-defined
+targets, because the lock already records every resolved target from past runs.
 
-To stay correct in the presence of per-test `record(target=...)` marks and
-fixture-defined profiles, these commands always run an internal
-`pytest --setup-only` pass. The real `ditto_target_profiles` /
-`ditto_storage_options` fixtures resolve each backend.
+Pass `--live` to read the live backends instead (an internal `pytest --setup-only`
+pass that resolves real fixtures and per-test `record(target=…)` marks). `--live`
+imports your test modules and needs the same credentials your test run needs.
 
-This means these commands:
-
-- Import your test modules
-- Need the same runtime credentials your test run needs
-- Are slower than a plain directory listing even for local-only projects
+Remote snapshots read from the lock have no physical size or modified date (shown
+as `—`); use `--live` for those. See [The Lock File](../guides/lock-file.md).
 
 `ditto clean` remains local-only and never touches remote snapshots.

--- a/docs/src/cli/lint.md
+++ b/docs/src/cli/lint.md
@@ -31,3 +31,20 @@ ditto lint tests/ci/
 
 - `0` — No issues found
 - `1` — One or more issues detected
+
+## Data source
+
+By default this command is **credential-free**: local snapshots are read from the
+filesystem (real size and modified date, including on-disk orphans) and remote
+snapshots are read from `ditto.lock` (shown with `—` for size and modified, since
+physical metadata needs a live connection). No test modules are imported and no
+credentials are needed.
+
+Pass `--live` to read the live backends instead, via an internal
+`pytest --setup-only` pass — authoritative physical state for every target, at the
+cost of importing your tests and needing their credentials.
+
+The empty-file check is skipped for snapshots whose size is unknown without
+`--live`.
+
+See [The Lock File](../guides/lock-file.md#declared-vs-physical-state-and-the-inventory-trade-off).

--- a/docs/src/cli/list.md
+++ b/docs/src/cli/list.md
@@ -34,3 +34,17 @@ Displays a table with columns:
 | Recorder | Format used (pkl, yaml, json, etc.) |
 | Size | File size |
 | Modified | Last-modified date |
+
+## Data source
+
+By default this command is **credential-free**: local snapshots are read from the
+filesystem (real size and modified date, including on-disk orphans) and remote
+snapshots are read from `ditto.lock` (shown with `—` for size and modified, since
+physical metadata needs a live connection). No test modules are imported and no
+credentials are needed.
+
+Pass `--live` to read the live backends instead, via an internal
+`pytest --setup-only` pass — authoritative physical state for every target, at the
+cost of importing your tests and needing their credentials.
+
+See [The Lock File](../guides/lock-file.md#declared-vs-physical-state-and-the-inventory-trade-off).

--- a/docs/src/cli/stats.md
+++ b/docs/src/cli/stats.md
@@ -29,3 +29,20 @@ Displays a table with columns:
 | Directory | Path to the `.ditto/` directory |
 | Files | Number of snapshot files |
 | Size | Total size of snapshots in that directory |
+
+## Data source
+
+By default this command is **credential-free**: local snapshots are read from the
+filesystem (real size and modified date, including on-disk orphans) and remote
+snapshots are read from `ditto.lock` (shown with `—` for size and modified, since
+physical metadata needs a live connection). No test modules are imported and no
+credentials are needed.
+
+Pass `--live` to read the live backends instead, via an internal
+`pytest --setup-only` pass — authoritative physical state for every target, at the
+cost of importing your tests and needing their credentials.
+
+Totals cover only snapshots with a known size; remote (lock-derived) snapshots are
+reported separately as "size unknown (use --live)".
+
+See [The Lock File](../guides/lock-file.md#declared-vs-physical-state-and-the-inventory-trade-off).

--- a/docs/src/cli/status.md
+++ b/docs/src/cli/status.md
@@ -31,3 +31,20 @@ Displays:
 - Total size on disk
 - Breakdown by recorder type (count and size)
 - Oldest and newest snapshot dates
+
+## Data source
+
+By default this command is **credential-free**: local snapshots are read from the
+filesystem (real size and modified date, including on-disk orphans) and remote
+snapshots are read from `ditto.lock` (shown with `—` for size and modified, since
+physical metadata needs a live connection). No test modules are imported and no
+credentials are needed.
+
+Pass `--live` to read the live backends instead, via an internal
+`pytest --setup-only` pass — authoritative physical state for every target, at the
+cost of importing your tests and needing their credentials.
+
+Totals cover only snapshots with a known size; remote (lock-derived) snapshots are
+reported separately as "size unknown (use --live)".
+
+See [The Lock File](../guides/lock-file.md#declared-vs-physical-state-and-the-inventory-trade-off).

--- a/docs/src/cli/verify.md
+++ b/docs/src/cli/verify.md
@@ -1,0 +1,38 @@
+# ditto verify
+
+Checks the live backend against the committed `ditto.lock` and fails when they
+have drifted. Read-only — it never writes snapshots or the lock. Intended for CI.
+
+See [The Lock File](../guides/lock-file.md) for the model.
+
+## Usage
+
+```
+ditto verify [PYTEST_ARGS]
+```
+
+`ditto verify` re-runs your suite with `--ditto-verify`; extra arguments are
+passed through to pytest.
+
+## Examples
+
+```bash
+# Fail CI if the backend has drifted from ditto.lock
+ditto verify
+
+# Verify a subset (only the exercised targets are checked)
+ditto verify tests/ci/
+```
+
+## What it reports
+
+| Drift | Meaning |
+|---|---|
+| missing | Recorded in `ditto.lock` but absent from the backend. |
+| orphan | Present in the backend (under an owned prefix) but not in the lock. |
+| unsynced | Produced this run but not yet in the lock — run `ditto lock`. |
+
+Any drift, a missing or corrupt lock, or an unreachable target fails the run
+(non-zero exit). A filtered run (`-k`/`-m`) warns that it only checked the
+exercised targets. `--ditto-verify` cannot be combined with the write flags
+(`--ditto-update` / `--ditto-lock` / `--ditto-prune` / `--ditto-prune-dry-run`).

--- a/docs/src/guides/lock-file.md
+++ b/docs/src/guides/lock-file.md
@@ -1,0 +1,81 @@
+# The Lock File
+
+`ditto.lock` is a tool-generated, committed, PR-reviewed file that records which
+snapshots your test suite legitimately owns. It is the source of truth behind
+`ditto verify`, `ditto prune`, and the credential-free CLI inventory.
+
+It is modelled on `package-lock.json`, `Cargo.lock`, and `poetry.lock`: never
+hand-edited, deterministic, merge-friendly, and reviewed as part of the diff.
+
+## Why a committed file
+
+A snapshot is "legitimate" only if your suite is supposed to own it. That fact
+cannot be derived from which tests happened to run in one session, and a
+throwaway cache cannot survive a fresh CI checkout. `ditto.lock` persists it: it
+is committed, so a clean checkout — or a partial, failed, or parallel run — still
+knows the full, authoritative set.
+
+Commit `ditto.lock`. Do **not** add it to `.gitignore`; ditto warns when it is
+ignored.
+
+## What it records
+
+For each resolved **target** (a backend URI such as the local `.ditto/`
+directory or `redis://…`), the lock stores one entry per snapshot: the test
+`nodeid`, the snapshot `key`, and the recorder. It records the targets your tests
+actually used — including per-test `record(target=…)` marks — because it is
+written by real runs. It never stores credentials or `storage_options`.
+
+## How it is produced and maintained
+
+| Command | Effect on `ditto.lock` |
+|---|---|
+| `pytest` (normal run) | Appends entries for any snapshots recorded this run. |
+| `ditto lock` (`pytest --ditto-lock`) | Rebuilds the lock from a full run (authoritative; drops stale entries). Refuses on a partial/filtered run. |
+| `ditto update` (`pytest --ditto-update`) | On a full run, reconciles the lock (drops entries for deleted tests); on a filtered run, appends only. |
+| `ditto prune` (`pytest --ditto-prune`) | Does **not** write the lock; deletes backend snapshots absent from it. |
+
+Owned-prefix scoping keeps a shared backend safe: ditto only considers keys under
+the modules your suite owns, so two suites or branches sharing one backend never
+delete each other's data.
+
+## How the lock is used
+
+- **`ditto verify`** — diffs the live backend against the lock and fails on drift
+  (missing, orphan, or unsynced snapshots). See [ditto verify](../cli/verify.md).
+- **`ditto prune`** — deletes backend snapshots that are not in the lock, never a
+  snapshot created during the same run. See [ditto prune](../cli/prune.md).
+- **CLI inventory** (`list`/`status`/`stats`/`lint`) — reads the lock for a fast,
+  credential-free remote inventory (below).
+
+## Declared vs physical state (and the inventory trade-off)
+
+The lock is a **declared** record — what is *legitimate* — not a **physical** one
+— what is *actually stored*. They can diverge: a snapshot deleted from the backend
+but still in the lock (missing), or an orphan in the backend not in the lock.
+Detecting that divergence is exactly what `ditto verify` is for.
+
+This shapes how the read-only inventory commands source their data:
+
+```mermaid
+flowchart TD
+    C["ditto list / status / stats / lint"] --> L{"--live?"}
+    L -- "yes" --> P["pytest --setup-only pass<br/>(physical, all targets, needs credentials)"]
+    L -- "no (default)" --> T{"per target"}
+    T -- "local file://" --> F["filesystem walk<br/>(real size + mtime, shows orphans)"]
+    T -- "remote (redis://, s3://, …)" --> K["ditto.lock<br/>(declared entries, size = —)"]
+```
+
+- **Local file targets are read from disk** — real sizes and mtimes, including
+  on-disk orphans not in the lock — instantly and without credentials.
+- **Remote targets are read from the lock** — credential-free, but size and
+  mtime are unknown (shown as `—`).
+- **`--live`** runs the pytest introspection pass for authoritative physical
+  state across every target. It imports your test modules and needs the same
+  credentials your test run needs.
+
+The reason for the split is a hard asymmetry: reading a local file's true state
+is free (a `stat`), but reading a remote backend's true state requires connecting
+to it, which is credential-gated. You can have at most two of *{uniform
+behaviour, true physical state, fast & credential-free}* — ditto's default keeps
+inventory fast and credential-free, and offers truth on demand via `--live`.

--- a/src/ditto/_inventory.py
+++ b/src/ditto/_inventory.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
+from urllib.parse import urlparse
 
 from ._cli_introspect import run_introspect
 from ._lockfile import LOCKFILE_NAME, LockFile, read_lockfile, storage_key
@@ -53,14 +54,22 @@ def _nodeid_under(nodeid: str, rootdir: Path, base: Path) -> bool:
     return _is_within(resolved, base)
 
 
+def _file_target_path(target_id: str, rootdir: Path) -> Path:
+    """Resolve a portable lock target id to its local filesystem path."""
+    parsed = urlparse(target_id)
+    if parsed.scheme == "file":
+        return Path(parsed.netloc + parsed.path).resolve()
+    return (rootdir / target_id).resolve()
+
+
 def _local_ditto_dirs(
     path: Path, lock: LockFile | None, rootdir: Path | None
 ) -> list[Path]:
     """Locate every `.ditto` directory to inventory under `path`.
 
     Walks `path` for `.ditto` directories and adds any `file`-scheme target
-    directory recorded in `lock` that falls under `path` (deduplicated by
-    resolved path, insertion-ordered for stable output).
+    directory recorded in `lock` whose directory or owning tests fall under
+    `path` (deduplicated by resolved path, insertion-ordered for stable output).
 
     Parameters
     ----------
@@ -85,8 +94,11 @@ def _local_ditto_dirs(
         for target_id, target in lock.targets.items():
             if target.scheme != "file":
                 continue
-            resolved = (rootdir / target_id).resolve()
-            if resolved.is_dir() and _is_within(resolved, base):
+            resolved = _file_target_path(target_id, rootdir)
+            tests_in_scope = any(
+                _nodeid_under(entry.nodeid, rootdir, base) for entry in target.entries
+            )
+            if resolved.is_dir() and (_is_within(resolved, base) or tests_in_scope):
                 dirs.setdefault(resolved)
     return list(dirs)
 
@@ -114,9 +126,7 @@ def _read_ditto_dir(directory: Path) -> list[ManifestEntry]:
     return entries
 
 
-def _walk_local(
-    path: Path, lock: LockFile | None, rootdir: Path | None
-) -> Manifest:
+def _walk_local(path: Path, lock: LockFile | None, rootdir: Path | None) -> Manifest:
     """Inventory local `file` snapshots from disk under `path`.
 
     One `BackendManifest` per non-empty `.ditto/` directory located by

--- a/src/ditto/_inventory.py
+++ b/src/ditto/_inventory.py
@@ -14,6 +14,7 @@ physical state across every target.
 
 from __future__ import annotations
 
+import stat
 import warnings
 from pathlib import Path
 from urllib.parse import urlparse
@@ -24,7 +25,11 @@ from ._manifest import BackendManifest, Manifest, ManifestEntry
 from .exceptions import DittoLockFileError, DittoWarning
 
 
-__all__ = ("build_inventory", "lock_present")
+__all__ = ("InventoryError", "build_inventory", "lock_present")
+
+
+class InventoryError(RuntimeError):
+    """Raised when a credential-free inventory cannot be read completely."""
 
 
 def _find_lock(path: Path) -> Path | None:
@@ -107,20 +112,30 @@ def _read_ditto_dir(directory: Path) -> list[ManifestEntry]:
     """Stat each file in `directory` into a manifest entry (real size + mtime).
 
     Files that vanish between listing and stat are skipped rather than raising.
+    Other filesystem errors fail the inventory rather than hiding snapshots.
     """
     entries: list[ManifestEntry] = []
-    for child in sorted(directory.iterdir()):
-        if not child.is_file():
-            continue
+    try:
+        children = sorted(directory.iterdir())
+    except OSError as exc:
+        raise InventoryError(
+            f"Could not read snapshot directory {directory}: {exc}"
+        ) from exc
+
+    for child in children:
         try:
-            stat = child.stat()
-        except OSError:
+            child_stat = child.stat()
+        except FileNotFoundError:
             continue  # vanished between listing and stat (e.g. concurrent prune)
+        except OSError as exc:
+            raise InventoryError(f"Could not inspect snapshot {child}: {exc}") from exc
+        if not stat.S_ISREG(child_stat.st_mode):
+            continue
         entries.append(
             ManifestEntry(
                 storage_key=child.name,
-                size_bytes=stat.st_size,
-                modified=stat.st_mtime,
+                size_bytes=child_stat.st_size,
+                modified=child_stat.st_mtime,
             )
         )
     return entries

--- a/src/ditto/_inventory.py
+++ b/src/ditto/_inventory.py
@@ -1,0 +1,193 @@
+"""Credential-free CLI inventory: read snapshots from disk and the lock file.
+
+The read-only inventory commands (`list`, `status`, `stats`, `lint`) assemble a
+`Manifest` from the cheapest credential-free source per target:
+
+- local `file` targets are read from the filesystem (real size and mtime,
+  including orphans not in the lock);
+- remote (non-`file`) targets are read from the committed `ditto.lock` (the
+  declared set; size and mtime are unknown without a live backend connection).
+
+`--live` selects the pytest introspection pass instead, for authoritative
+physical state across every target.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+from ._cli_introspect import run_introspect
+from ._lockfile import LOCKFILE_NAME, LockFile, read_lockfile, storage_key
+from ._manifest import BackendManifest, Manifest, ManifestEntry
+from .exceptions import DittoLockFileError, DittoWarning
+
+
+__all__ = ("build_inventory", "lock_present")
+
+
+def _find_lock(path: Path) -> Path | None:
+    """Search `path` and its ancestors for `ditto.lock`; return it or `None`."""
+    start = path.resolve()
+    for directory in (start, *start.parents):
+        candidate = directory / LOCKFILE_NAME
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def lock_present(path: Path) -> bool:
+    """Return whether a `ditto.lock` governs `path` (for the no-lock hint)."""
+    return _find_lock(path) is not None
+
+
+def _is_within(resolved: Path, base: Path) -> bool:
+    """Return whether `resolved` is `base` itself or nested under it."""
+    return resolved == base or base in resolved.parents
+
+
+def _nodeid_under(nodeid: str, rootdir: Path, base: Path) -> bool:
+    """Return whether a lock entry's test file falls under `base` (the PATH)."""
+    file_part = nodeid.split("::", 1)[0]
+    resolved = (rootdir / file_part).resolve()
+    return _is_within(resolved, base)
+
+
+def _walk_local(path: Path, lock: LockFile | None, rootdir: Path | None) -> Manifest:
+    """Inventory local `file` snapshots from disk under `path`.
+
+    Walks every `.ditto/` directory under `path`, plus any `file`-scheme target
+    directory recorded in `lock` that falls under `path` (deduplicated by
+    resolved path). Each file is stat'd for real size and mtime, so on-disk
+    orphans absent from the lock still appear.
+
+    Parameters
+    ----------
+    path
+        The directory to inventory.
+    lock
+        The parsed lock file, or `None` when absent or unreadable.
+    rootdir
+        The directory containing `ditto.lock`, used to resolve relative target
+        ids, or `None` when there is no lock.
+
+    Returns
+    -------
+    Manifest
+        One `BackendManifest` per non-empty `.ditto/` directory.
+    """
+    base = path.resolve()
+    dirs: dict[Path, None] = {}
+    for ditto_dir in base.rglob(".ditto"):
+        if ditto_dir.is_dir():
+            dirs[ditto_dir.resolve()] = None
+    if lock is not None and rootdir is not None:
+        for target_id, target in lock.targets.items():
+            if target.scheme != "file":
+                continue
+            resolved = (rootdir / target_id).resolve()
+            if resolved.is_dir() and _is_within(resolved, base):
+                dirs[resolved] = None
+
+    backends: Manifest = []
+    for directory in dirs:
+        entries: list[ManifestEntry] = []
+        for child in sorted(directory.iterdir()):
+            if not child.is_file():
+                continue
+            try:
+                stat = child.stat()
+            except OSError:
+                continue  # vanished between listing and stat (e.g. concurrent prune)
+            entries.append(
+                ManifestEntry(
+                    storage_key=child.name,
+                    size_bytes=stat.st_size,
+                    modified=stat.st_mtime,
+                )
+            )
+        if entries:
+            backends.append(BackendManifest(location=str(directory), entries=entries))
+    return backends
+
+
+def _lock_remote(lock: LockFile | None, path: Path, rootdir: Path | None) -> Manifest:
+    """Inventory remote (non-`file`) targets from the lock, scoped to `path`.
+
+    Each entry whose test file falls under `path` becomes a `ManifestEntry` with
+    `size_bytes=None` and `modified=None` (physical metadata is unknown without a
+    live backend connection).
+
+    Parameters
+    ----------
+    lock
+        The parsed lock file, or `None` when absent or unreadable.
+    path
+        The directory the inventory is scoped to.
+    rootdir
+        The directory containing `ditto.lock`, used to resolve nodeids, or
+        `None` when there is no lock.
+
+    Returns
+    -------
+    Manifest
+        One `BackendManifest` per remote target with in-scope entries.
+    """
+    if lock is None or rootdir is None:
+        return []
+    base = path.resolve()
+    backends: Manifest = []
+    for target_id, target in lock.targets.items():
+        if target.scheme == "file":
+            continue
+        entries = [
+            ManifestEntry(
+                storage_key=storage_key(entry, target.scheme),
+                size_bytes=None,
+                modified=None,
+            )
+            for entry in target.entries
+            if _nodeid_under(entry.nodeid, rootdir, base)
+        ]
+        if entries:
+            backends.append(BackendManifest(location=target_id, entries=entries))
+    return backends
+
+
+def build_inventory(path: Path, *, live: bool) -> Manifest:
+    """Assemble the snapshot inventory for `path`.
+
+    By default reads credential-free from the filesystem (local) and `ditto.lock`
+    (remote). With `live=True`, runs the pytest introspection pass for
+    authoritative physical state across every target.
+
+    Parameters
+    ----------
+    path
+        The directory to inventory.
+    live
+        When `True`, delegate to the live introspection pass; otherwise build the
+        credential-free inventory from disk and the lock file.
+
+    Returns
+    -------
+    Manifest
+        The assembled inventory.
+    """
+    if live:
+        return run_introspect(path)
+    lock_path = _find_lock(path)
+    rootdir = lock_path.parent if lock_path is not None else None
+    lock: LockFile | None = None
+    if lock_path is not None:
+        try:
+            lock = read_lockfile(lock_path)
+        except DittoLockFileError as exc:
+            warnings.warn(
+                f"{LOCKFILE_NAME} is unreadable ({exc}); showing local snapshots "
+                "only — use --live for the full inventory.",
+                category=DittoWarning,
+                stacklevel=2,
+            )
+            lock = None
+    return _walk_local(path, lock, rootdir) + _lock_remote(lock, path, rootdir)

--- a/src/ditto/_inventory.py
+++ b/src/ditto/_inventory.py
@@ -78,17 +78,16 @@ def _local_ditto_dirs(
         Distinct `.ditto` directories to read, in insertion order.
     """
     base = path.resolve()
-    dirs: dict[Path, None] = {}
-    for ditto_dir in base.rglob(".ditto"):
-        if ditto_dir.is_dir():
-            dirs[ditto_dir.resolve()] = None
+    dirs: dict[Path, None] = dict.fromkeys(
+        d.resolve() for d in base.rglob(".ditto") if d.is_dir()
+    )
     if lock is not None and rootdir is not None:
         for target_id, target in lock.targets.items():
             if target.scheme != "file":
                 continue
             resolved = (rootdir / target_id).resolve()
             if resolved.is_dir() and _is_within(resolved, base):
-                dirs[resolved] = None
+                dirs.setdefault(resolved)
     return list(dirs)
 
 

--- a/src/ditto/_inventory.py
+++ b/src/ditto/_inventory.py
@@ -53,13 +53,14 @@ def _nodeid_under(nodeid: str, rootdir: Path, base: Path) -> bool:
     return _is_within(resolved, base)
 
 
-def _walk_local(path: Path, lock: LockFile | None, rootdir: Path | None) -> Manifest:
-    """Inventory local `file` snapshots from disk under `path`.
+def _local_ditto_dirs(
+    path: Path, lock: LockFile | None, rootdir: Path | None
+) -> list[Path]:
+    """Locate every `.ditto` directory to inventory under `path`.
 
-    Walks every `.ditto/` directory under `path`, plus any `file`-scheme target
+    Walks `path` for `.ditto` directories and adds any `file`-scheme target
     directory recorded in `lock` that falls under `path` (deduplicated by
-    resolved path). Each file is stat'd for real size and mtime, so on-disk
-    orphans absent from the lock still appear.
+    resolved path, insertion-ordered for stable output).
 
     Parameters
     ----------
@@ -73,8 +74,8 @@ def _walk_local(path: Path, lock: LockFile | None, rootdir: Path | None) -> Mani
 
     Returns
     -------
-    Manifest
-        One `BackendManifest` per non-empty `.ditto/` directory.
+    list[Path]
+        Distinct `.ditto` directories to read, in insertion order.
     """
     base = path.resolve()
     dirs: dict[Path, None] = {}
@@ -88,24 +89,44 @@ def _walk_local(path: Path, lock: LockFile | None, rootdir: Path | None) -> Mani
             resolved = (rootdir / target_id).resolve()
             if resolved.is_dir() and _is_within(resolved, base):
                 dirs[resolved] = None
+    return list(dirs)
 
-    backends: Manifest = []
-    for directory in dirs:
-        entries: list[ManifestEntry] = []
-        for child in sorted(directory.iterdir()):
-            if not child.is_file():
-                continue
-            try:
-                stat = child.stat()
-            except OSError:
-                continue  # vanished between listing and stat (e.g. concurrent prune)
-            entries.append(
-                ManifestEntry(
-                    storage_key=child.name,
-                    size_bytes=stat.st_size,
-                    modified=stat.st_mtime,
-                )
+
+def _read_ditto_dir(directory: Path) -> list[ManifestEntry]:
+    """Stat each file in `directory` into a manifest entry (real size + mtime).
+
+    Files that vanish between listing and stat are skipped rather than raising.
+    """
+    entries: list[ManifestEntry] = []
+    for child in sorted(directory.iterdir()):
+        if not child.is_file():
+            continue
+        try:
+            stat = child.stat()
+        except OSError:
+            continue  # vanished between listing and stat (e.g. concurrent prune)
+        entries.append(
+            ManifestEntry(
+                storage_key=child.name,
+                size_bytes=stat.st_size,
+                modified=stat.st_mtime,
             )
+        )
+    return entries
+
+
+def _walk_local(
+    path: Path, lock: LockFile | None, rootdir: Path | None
+) -> Manifest:
+    """Inventory local `file` snapshots from disk under `path`.
+
+    One `BackendManifest` per non-empty `.ditto/` directory located by
+    `_local_ditto_dirs`; each file is stat'd for real size and mtime, so
+    on-disk orphans absent from the lock still appear.
+    """
+    backends: Manifest = []
+    for directory in _local_ditto_dirs(path, lock, rootdir):
+        entries = _read_ditto_dir(directory)
         if entries:
             backends.append(BackendManifest(location=str(directory), entries=entries))
     return backends
@@ -154,28 +175,15 @@ def _lock_remote(lock: LockFile | None, path: Path, rootdir: Path | None) -> Man
     return backends
 
 
-def build_inventory(path: Path, *, live: bool) -> Manifest:
-    """Assemble the snapshot inventory for `path`.
+def _build_credential_free_inventory(path: Path) -> Manifest:
+    """Assemble the inventory for `path` without importing tests.
 
-    By default reads credential-free from the filesystem (local) and `ditto.lock`
-    (remote). With `live=True`, runs the pytest introspection pass for
-    authoritative physical state across every target.
-
-    Parameters
-    ----------
-    path
-        The directory to inventory.
-    live
-        When `True`, delegate to the live introspection pass; otherwise build the
-        credential-free inventory from disk and the lock file.
-
-    Returns
-    -------
-    Manifest
-        The assembled inventory.
+    Reads local `file` snapshots from the filesystem (real size and mtime,
+    including on-disk orphans) and remote (non-`file`) snapshots from the
+    committed `ditto.lock` (declared entries; size and mtime unknown). A
+    missing lock yields a local-only inventory; a corrupt lock warns
+    (`DittoWarning`) and degrades to local-only rather than failing.
     """
-    if live:
-        return run_introspect(path)
     lock_path = _find_lock(path)
     rootdir = lock_path.parent if lock_path is not None else None
     lock: LockFile | None = None
@@ -191,3 +199,15 @@ def build_inventory(path: Path, *, live: bool) -> Manifest:
             )
             lock = None
     return _walk_local(path, lock, rootdir) + _lock_remote(lock, path, rootdir)
+
+
+def build_inventory(path: Path, *, live: bool) -> Manifest:
+    """Assemble the snapshot inventory for `path`.
+
+    By default reads credential-free from the filesystem (local) and `ditto.lock`
+    (remote). With `live=True`, runs the pytest introspection pass for
+    authoritative physical state across every target.
+    """
+    if live:
+        return run_introspect(path)
+    return _build_credential_free_inventory(path)

--- a/src/ditto/_manifest.py
+++ b/src/ditto/_manifest.py
@@ -12,11 +12,16 @@ from dataclasses import asdict, dataclass
 
 @dataclass(frozen=True)
 class ManifestEntry:
-    """One stored snapshot. `modified` is a POSIX timestamp when the backend's
-    filesystem reports one (local files, S3), else None (e.g. Redis)."""
+    """One stored snapshot.
+
+    `size_bytes` is the byte size when known, or `None` when the inventory was
+    read credential-free from `ditto.lock` (a remote snapshot whose physical size
+    needs `--live`). `modified` is a POSIX timestamp when the backend reports one
+    (local files, S3), else `None`.
+    """
 
     storage_key: str
-    size_bytes: int
+    size_bytes: int | None
     modified: float | None
 
 

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -54,7 +54,7 @@ from ._theme import (
 )
 from ._manifest import Manifest, ManifestEntry
 from ._cli_introspect import IntrospectError
-from ._inventory import build_inventory, lock_present
+from ._inventory import InventoryError, build_inventory, lock_present
 
 console = Console()
 
@@ -112,6 +112,9 @@ def _inventory_or_exit(path: Path, *, live: bool) -> Manifest:
         return build_inventory(path, live=live)
     except IntrospectError as exc:
         console.print(f"[bold {PRUNED}]Introspection failed:[/bold {PRUNED}] {exc}")
+        sys.exit(1)
+    except InventoryError as exc:
+        console.print(f"[bold {PRUNED}]Inventory failed:[/bold {PRUNED}] {exc}")
         sys.exit(1)
 
 

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -149,7 +149,9 @@ def _recorder_name(ext: str, ext_map: Mapping[str, RecorderInfo]) -> str:
     return ext.lstrip(".")
 
 
-def _human_size(n: int) -> str:
+def _human_size(n: int | None) -> str:
+    if n is None:
+        return "—"
     value: float = n
     for unit in ("B", "KB", "MB", "GB"):
         if value < 1024:
@@ -180,11 +182,12 @@ def gather_stats(
     newest: tuple[float, str] | None = None
 
     for entry in entries:
-        total_size += entry.size_bytes
+        size = entry.size_bytes if entry.size_bytes is not None else 0
+        total_size += size
         _, _, ext = _parse_snapshot_name(entry.storage_key)
         recorder_name = _recorder_name(ext, ext_map)
         count, total = by_recorder.get(recorder_name, (0, 0))
-        by_recorder[recorder_name] = (count + 1, total + entry.size_bytes)
+        by_recorder[recorder_name] = (count + 1, total + size)
 
         if entry.modified is not None:
             if oldest is None or entry.modified < oldest[0]:

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -56,8 +56,16 @@ from ._manifest import Manifest, ManifestEntry
 from ._cli_introspect import IntrospectError
 from ._inventory import build_inventory, lock_present
 
-
 console = Console()
+
+_live_option = click.option(
+    "--live",
+    is_flag=True,
+    default=False,
+    help="Read live backends via a pytest pass (needs credentials) instead of "
+    "the credential-free filesystem + ditto.lock inventory.",
+)
+
 
 _RECORDER_PALETTE = (
     ACCENT,  # peach
@@ -390,13 +398,7 @@ def cmd_verify(pytest_args):
 
 
 @cli.command(name="list")
-@click.option(
-    "--live",
-    is_flag=True,
-    default=False,
-    help="Read live backends via a pytest pass (needs credentials) instead of "
-    "the credential-free filesystem + ditto.lock inventory.",
-)
+@_live_option
 @click.argument(
     "path", default=".", type=click.Path(exists=True, file_okay=False, path_type=Path)
 )
@@ -500,13 +502,7 @@ def cmd_clean(path: Path, yes: bool):
 
 
 @cli.command(name="status")
-@click.option(
-    "--live",
-    is_flag=True,
-    default=False,
-    help="Read live backends via a pytest pass (needs credentials) instead of "
-    "the credential-free filesystem + ditto.lock inventory.",
-)
+@_live_option
 @click.argument(
     "path", default=".", type=click.Path(exists=True, file_okay=False, path_type=Path)
 )
@@ -760,13 +756,7 @@ def cmd_doctor():
 
 
 @cli.command(name="lint")
-@click.option(
-    "--live",
-    is_flag=True,
-    default=False,
-    help="Read live backends via a pytest pass (needs credentials) instead of "
-    "the credential-free filesystem + ditto.lock inventory.",
-)
+@_live_option
 @click.argument(
     "path", default=".", type=click.Path(exists=True, file_okay=False, path_type=Path)
 )
@@ -794,13 +784,7 @@ def cmd_lint(path: Path, live: bool):
 
 
 @cli.command(name="stats")
-@click.option(
-    "--live",
-    is_flag=True,
-    default=False,
-    help="Read live backends via a pytest pass (needs credentials) instead of "
-    "the credential-free filesystem + ditto.lock inventory.",
-)
+@_live_option
 @click.argument(
     "path", default=".", type=click.Path(exists=True, file_okay=False, path_type=Path)
 )

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -466,6 +466,7 @@ def cmd_list(path: Path, live: bool):
     entries = _entries(manifest)
     if not entries:
         console.print(f"[{MUTED}]No snapshot files found.[/{MUTED}]")
+        _print_inventory_notes(path, entries, live=live)
         sys.exit(1)
 
     infos = _load_recorder_infos()
@@ -570,6 +571,7 @@ def cmd_status(path: Path, live: bool):
     entries = _entries(manifest)
     if not entries:
         console.print(f"[{MUTED}]No snapshot files found.[/{MUTED}]")
+        _print_inventory_notes(path, entries, live=live)
         sys.exit(1)
 
     render_stats(gather_stats(entries, _ext_map(_load_recorder_infos())), console)
@@ -857,6 +859,7 @@ def cmd_stats(path: Path, live: bool):
     manifest = _inventory_or_exit(path, live=live)
     if not manifest:
         console.print(f"[{MUTED}]No snapshot files found.[/{MUTED}]")
+        _print_inventory_notes(path, [], live=live)
         sys.exit(1)
     em = _ext_map(_load_recorder_infos())
     dir_stats = [(b.location, gather_stats(b.entries, em)) for b in manifest]

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -53,7 +53,8 @@ from ._theme import (
     FLAMINGO,
 )
 from ._manifest import Manifest, ManifestEntry
-from ._cli_introspect import IntrospectError, run_introspect
+from ._cli_introspect import IntrospectError
+from ._inventory import build_inventory, lock_present
 
 
 console = Console()
@@ -97,18 +98,33 @@ def _find_ditto_dirs(root: Path) -> list[Path]:
     return sorted(p for p in root.rglob(".ditto") if p.is_dir())
 
 
-def _inventory_or_exit(path: Path) -> Manifest:
-    """Run the introspection pass for PATH, or print the error and exit(1).
-
-    Always introspects: the pytest pass resolves real fixtures and per-test
-    record(target=...) marks, so the inventory covers local file://, remote, and
-    fixture-defined backends with nothing inferred from static config.
-    """
+def _inventory_or_exit(path: Path, *, live: bool) -> Manifest:
+    """Build the inventory for PATH, or print the error and exit(1)."""
     try:
-        return run_introspect(path)
+        return build_inventory(path, live=live)
     except IntrospectError as exc:
         console.print(f"[bold {PRUNED}]Introspection failed:[/bold {PRUNED}] {exc}")
         sys.exit(1)
+
+
+def _print_inventory_notes(
+    path: Path, entries: list[ManifestEntry], *, live: bool
+) -> None:
+    """Print muted hints about unknown remote sizes and a missing lock file."""
+    if live:
+        return
+    unknown = sum(1 for entry in entries if entry.size_bytes is None)
+    if unknown:
+        plural = "s" if unknown != 1 else ""
+        console.print(
+            f"[{MUTED}]remote: {unknown} snapshot{plural}, "
+            f"size unknown (use --live).[/{MUTED}]"
+        )
+    if not lock_present(path):
+        console.print(
+            f"[{MUTED}]no ditto.lock found — remote snapshots are not shown; "
+            f"use --live.[/{MUTED}]"
+        )
 
 
 def _entries(manifest: Manifest) -> list[ManifestEntry]:
@@ -374,18 +390,28 @@ def cmd_verify(pytest_args):
 
 
 @cli.command(name="list")
+@click.option(
+    "--live",
+    is_flag=True,
+    default=False,
+    help="Read live backends via a pytest pass (needs credentials) instead of "
+    "the credential-free filesystem + ditto.lock inventory.",
+)
 @click.argument(
     "path", default=".", type=click.Path(exists=True, file_okay=False, path_type=Path)
 )
-def cmd_list(path: Path):
+def cmd_list(path: Path, live: bool):
     """List all snapshot files under PATH (default: current directory).
+
+    By default reads local snapshots from disk and remote snapshots from
+    ditto.lock (credential-free); pass --live to read live backends.
 
     \b
     Examples:
       ditto list
       ditto list tests/ci/
     """
-    manifest = _inventory_or_exit(path)
+    manifest = _inventory_or_exit(path, live=live)
     entries = _entries(manifest)
     if not entries:
         console.print(f"[{MUTED}]No snapshot files found.[/{MUTED}]")
@@ -424,6 +450,7 @@ def cmd_list(path: Path):
         )
 
     console.print(table)
+    _print_inventory_notes(path, entries, live=live)
 
 
 @cli.command(name="clean")
@@ -473,24 +500,35 @@ def cmd_clean(path: Path, yes: bool):
 
 
 @cli.command(name="status")
+@click.option(
+    "--live",
+    is_flag=True,
+    default=False,
+    help="Read live backends via a pytest pass (needs credentials) instead of "
+    "the credential-free filesystem + ditto.lock inventory.",
+)
 @click.argument(
     "path", default=".", type=click.Path(exists=True, file_okay=False, path_type=Path)
 )
-def cmd_status(path: Path):
+def cmd_status(path: Path, live: bool):
     """Show aggregate statistics for snapshots under PATH.
+
+    By default aggregates local snapshots from disk and remote snapshots from
+    ditto.lock (credential-free); pass --live to read live backends.
 
     \b
     Examples:
       ditto status
       ditto status tests/ci/
     """
-    manifest = _inventory_or_exit(path)
+    manifest = _inventory_or_exit(path, live=live)
     entries = _entries(manifest)
     if not entries:
         console.print(f"[{MUTED}]No snapshot files found.[/{MUTED}]")
         sys.exit(1)
 
     render_stats(gather_stats(entries, _ext_map(_load_recorder_infos())), console)
+    _print_inventory_notes(path, entries, live=live)
 
 
 def _render_recorders(infos: list[RecorderInfo], console: Console) -> None:
@@ -722,42 +760,66 @@ def cmd_doctor():
 
 
 @cli.command(name="lint")
+@click.option(
+    "--live",
+    is_flag=True,
+    default=False,
+    help="Read live backends via a pytest pass (needs credentials) instead of "
+    "the credential-free filesystem + ditto.lock inventory.",
+)
 @click.argument(
     "path", default=".", type=click.Path(exists=True, file_okay=False, path_type=Path)
 )
-def cmd_lint(path: Path):
+def cmd_lint(path: Path, live: bool):
     """Check snapshot files for naming issues, unknown formats, and empty files.
+
+    By default lints local snapshots from disk and remote snapshots from
+    ditto.lock (credential-free); pass --live to read live backends.
 
     \b
     Examples:
       ditto lint
       ditto lint tests/ci/
     """
-    manifest = _inventory_or_exit(path)
-    issues = _find_lint_issues(_entries(manifest), _ext_map(_load_recorder_infos()))
-    if not issues:
+    manifest = _inventory_or_exit(path, live=live)
+    entries = _entries(manifest)
+    issues = _find_lint_issues(entries, _ext_map(_load_recorder_infos()))
+    if issues:
+        _render_lint_issues(issues, console)
+    else:
         console.print(f"[{MUTED}]All snapshots are valid.[/{MUTED}]")
-        return
-    _render_lint_issues(issues, console)
-    sys.exit(1)
+    _print_inventory_notes(path, entries, live=live)
+    if issues:
+        sys.exit(1)
 
 
 @cli.command(name="stats")
+@click.option(
+    "--live",
+    is_flag=True,
+    default=False,
+    help="Read live backends via a pytest pass (needs credentials) instead of "
+    "the credential-free filesystem + ditto.lock inventory.",
+)
 @click.argument(
     "path", default=".", type=click.Path(exists=True, file_okay=False, path_type=Path)
 )
-def cmd_stats(path: Path):
+def cmd_stats(path: Path, live: bool):
     """Show per-directory snapshot usage breakdown.
+
+    By default breaks down local snapshots from disk and remote snapshots from
+    ditto.lock (credential-free); pass --live to read live backends.
 
     \b
     Examples:
       ditto stats
       ditto stats tests/ci/
     """
-    manifest = _inventory_or_exit(path)
+    manifest = _inventory_or_exit(path, live=live)
     if not manifest:
         console.print(f"[{MUTED}]No snapshot files found.[/{MUTED}]")
         sys.exit(1)
     em = _ext_map(_load_recorder_infos())
     dir_stats = [(b.location, gather_stats(b.entries, em)) for b in manifest]
     _render_stats_table(dir_stats, console)
+    _print_inventory_notes(path, _entries(manifest), live=live)

--- a/src/ditto/cli.py
+++ b/src/ditto/cli.py
@@ -188,30 +188,73 @@ def _human_size(n: int | None) -> str:
 
 
 @dataclass(frozen=True)
+class SizeSummary:
+    known_bytes: int = 0
+    unknown_count: int = 0
+
+
+@dataclass(frozen=True)
+class RecorderStats:
+    count: int
+    size: SizeSummary
+
+
+@dataclass(frozen=True)
 class SnapshotStats:
     total_count: int
-    total_size: int
-    by_recorder: Mapping[str, tuple[int, int]]  # name → (count, bytes)
+    total_size: SizeSummary
+    by_recorder: Mapping[str, RecorderStats]
     oldest: tuple[float, str] | None
     newest: tuple[float, str] | None
+
+
+def _add_size(summary: SizeSummary, size_bytes: int | None) -> SizeSummary:
+    """Return `summary` with one known or unknown snapshot size added."""
+    if size_bytes is None:
+        return SizeSummary(summary.known_bytes, summary.unknown_count + 1)
+    return SizeSummary(summary.known_bytes + size_bytes, summary.unknown_count)
+
+
+def _sum_sizes(summaries: Iterable[SizeSummary]) -> SizeSummary:
+    """Combine size summaries without discarding unknown-size counts."""
+    known_bytes = 0
+    unknown_count = 0
+    for summary in summaries:
+        known_bytes += summary.known_bytes
+        unknown_count += summary.unknown_count
+    return SizeSummary(known_bytes=known_bytes, unknown_count=unknown_count)
+
+
+def _format_size_summary(summary: SizeSummary) -> str:
+    """Render a complete, partial, or entirely unknown size total."""
+    if summary.unknown_count == 0:
+        return _human_size(summary.known_bytes)
+    if summary.known_bytes == 0:
+        return "—"
+    return f"{_human_size(summary.known_bytes)} known"
 
 
 def gather_stats(
     entries: list[ManifestEntry], ext_map: Mapping[str, RecorderInfo]
 ) -> SnapshotStats:
     """Aggregate snapshot statistics from a list of ManifestEntry items."""
-    total_size = 0
-    by_recorder: dict[str, tuple[int, int]] = {}
+    total_size = SizeSummary()
+    by_recorder: dict[str, RecorderStats] = {}
     oldest: tuple[float, str] | None = None
     newest: tuple[float, str] | None = None
 
     for entry in entries:
-        size = entry.size_bytes if entry.size_bytes is not None else 0
-        total_size += size
+        total_size = _add_size(total_size, entry.size_bytes)
         _, _, ext = _parse_snapshot_name(entry.storage_key)
         recorder_name = _recorder_name(ext, ext_map)
-        count, total = by_recorder.get(recorder_name, (0, 0))
-        by_recorder[recorder_name] = (count + 1, total + size)
+        current = by_recorder.get(
+            recorder_name,
+            RecorderStats(count=0, size=SizeSummary()),
+        )
+        by_recorder[recorder_name] = RecorderStats(
+            count=current.count + 1,
+            size=_add_size(current.size, entry.size_bytes),
+        )
 
         if entry.modified is not None:
             if oldest is None or entry.modified < oldest[0]:
@@ -236,16 +279,22 @@ def render_stats(stats: SnapshotStats, console: Console) -> None:
     lines.append("  Total snapshots  ", style=MUTED)
     lines.append(f"{stats.total_count}\n", style=f"bold {TEXT}")
     lines.append("  Total size       ", style=MUTED)
-    lines.append(f"{_human_size(stats.total_size)}\n", style=f"bold {TEXT}")
+    lines.append(f"{_format_size_summary(stats.total_size)}\n", style=f"bold {TEXT}")
     lines.append("\n")
     lines.append("  By recorder:\n", style=f"bold {HEADER}")
     name_w = max(len(name) for name in stats.by_recorder.keys())
-    count_w = max(len(str(c)) for c, _ in stats.by_recorder.values())
-    size_w = max(len(_human_size(s)) for _, s in stats.by_recorder.values())
-    for name, (count, sz) in sorted(stats.by_recorder.items()):
+    count_w = max(len(str(recorder.count)) for recorder in stats.by_recorder.values())
+    size_w = max(
+        len(_format_size_summary(recorder.size))
+        for recorder in stats.by_recorder.values()
+    )
+    for name, recorder in sorted(stats.by_recorder.items()):
         lines.append(f"    {name:<{name_w}}", style=colour_map.get(name, MUTED))
-        lines.append(f"  {count:>{count_w}}  ", style=TEXT)
-        lines.append(f"{_human_size(sz):>{size_w}}\n", style=MUTED)
+        lines.append(f"  {recorder.count:>{count_w}}  ", style=TEXT)
+        lines.append(
+            f"{_format_size_summary(recorder.size):>{size_w}}\n",
+            style=MUTED,
+        )
 
     if stats.oldest and stats.newest:
         lines.append("\n")
@@ -720,20 +769,26 @@ def _render_stats_table(
     table.add_column("Recorders", footer_style=MUTED)
 
     total_count = sum(s.total_count for _, s in dir_stats)
-    total_size = sum(s.total_size for _, s in dir_stats)
+    total_size = _sum_sizes(s.total_size for _, s in dir_stats)
 
     for d, s in dir_stats:
         recorder_text = Text()
-        for i, (name, (cnt, _sz)) in enumerate(sorted(s.by_recorder.items())):
+        for i, (name, recorder) in enumerate(sorted(s.by_recorder.items())):
             if i:
                 recorder_text.append("  ")
-            recorder_text.append(f"{name}×{cnt}", style=colour_map.get(name, MUTED))
+            recorder_text.append(
+                f"{name}×{recorder.count}",
+                style=colour_map.get(name, MUTED),
+            )
         table.add_row(
-            d, str(s.total_count), _human_size(s.total_size), recorder_text
+            d,
+            str(s.total_count),
+            _format_size_summary(s.total_size),
+            recorder_text,
         )
 
     table.columns[1].footer = str(total_count)
-    table.columns[2].footer = _human_size(total_size)
+    table.columns[2].footer = _format_size_summary(total_size)
 
     console.print(table)
 

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -9,8 +9,11 @@ from ditto._manifest import BackendManifest, ManifestEntry
 from ditto.cli import (
     _RECORDER_PALETTE,
     RecorderInfo,
+    RecorderStats,
+    SizeSummary,
     _build_colour_map,
     _ext_map,
+    _format_size_summary,
     _human_size,
     _parse_snapshot_name,
     cli,
@@ -102,8 +105,19 @@ def test_human_size_renders_none_as_dash():
     assert _human_size(None) == "—"
 
 
-def test_gather_stats_excludes_unknown_sizes_from_total_but_counts_entries():
-    """Entries with unknown size are counted but contribute no bytes."""
+def test_gather_stats_counts_entries_with_unknown_sizes() -> None:
+    """An unknown byte size does not remove a snapshot from the total count."""
+    entries = [
+        ManifestEntry(storage_key="m.test_a@k.pkl", size_bytes=None, modified=None),
+    ]
+
+    stats = gather_stats(entries, {})
+
+    assert stats.total_count == 1
+
+
+def test_gather_stats_preserves_known_and_unknown_size_components() -> None:
+    """Known bytes and unknown snapshot counts remain distinct when aggregated."""
     entries = [
         ManifestEntry(storage_key="m.test_a@k.pkl", size_bytes=100, modified=None),
         ManifestEntry(storage_key="m.test_b@k.pkl", size_bytes=None, modified=None),
@@ -111,8 +125,30 @@ def test_gather_stats_excludes_unknown_sizes_from_total_but_counts_entries():
 
     stats = gather_stats(entries, {})
 
-    assert stats.total_count == 2
-    assert stats.total_size == 100
+    actual = stats.total_size
+
+    expected = SizeSummary(known_bytes=100, unknown_count=1)
+    assert actual == expected
+
+
+def test_formats_entirely_unknown_size_summary_as_dash() -> None:
+    """An aggregate with no known sizes renders as unknown rather than zero."""
+    summary = SizeSummary(known_bytes=0, unknown_count=2)
+
+    actual = _format_size_summary(summary)
+
+    expected = "—"
+    assert actual == expected
+
+
+def test_labels_known_bytes_when_size_summary_is_partial() -> None:
+    """A mixed aggregate identifies its byte total as only the known portion."""
+    summary = SizeSummary(known_bytes=100, unknown_count=2)
+
+    actual = _format_size_summary(summary)
+
+    expected = "100 B known"
+    assert actual == expected
 
 
 # ── _build_colour_map ─────────────────────────────────────────────────────────
@@ -181,8 +217,11 @@ def test_attributes_entry_to_recorder_when_extension_is_known() -> None:
     stats = gather_stats(entries, em)
 
     assert stats.total_count == 1
-    assert stats.total_size == 100
-    assert stats.by_recorder["pickle"] == (1, 100)
+    assert stats.total_size == SizeSummary(known_bytes=100)
+    assert stats.by_recorder["pickle"] == RecorderStats(
+        count=1,
+        size=SizeSummary(known_bytes=100),
+    )
 
 
 def test_attributes_unknown_extension_to_its_raw_name() -> None:
@@ -238,17 +277,18 @@ def test_sums_count_and_size_across_entries_of_one_recorder() -> None:
     stats = gather_stats(entries, em)
 
     assert stats.total_count == 3
-    assert stats.total_size == 600
-    assert stats.by_recorder["pickle"] == (3, 600)
+    assert stats.total_size == SizeSummary(known_bytes=600)
+    assert stats.by_recorder["pickle"] == RecorderStats(
+        count=3,
+        size=SizeSummary(known_bytes=600),
+    )
 
 
 # ── command inventory dispatch ─────────────────────────────────────────────────
 
 
 def _patch_inventory(monkeypatch, manifest: list[BackendManifest]) -> None:
-    monkeypatch.setattr(
-        "ditto._inventory.run_introspect", lambda path: manifest
-    )
+    monkeypatch.setattr("ditto._inventory.run_introspect", lambda path: manifest)
 
 
 def test_list_renders_snapshots_from_the_manifest(tmp_path, monkeypatch) -> None:

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -246,11 +246,14 @@ def test_sums_count_and_size_across_entries_of_one_recorder() -> None:
 
 
 def _patch_inventory(monkeypatch, manifest: list[BackendManifest]) -> None:
-    monkeypatch.setattr(cli_mod, "run_introspect", lambda path: manifest)
+    monkeypatch.setattr(
+        "ditto._inventory.run_introspect", lambda path: manifest
+    )
 
 
 def test_list_renders_snapshots_from_the_manifest(tmp_path, monkeypatch) -> None:
-    """`ditto list` renders the storage keys the introspection pass enumerated."""
+    """`ditto list --live` renders the storage keys the introspection pass
+    enumerated."""
     manifest = [
         BackendManifest(
             "file:///x/.ditto",
@@ -259,7 +262,7 @@ def test_list_renders_snapshots_from_the_manifest(tmp_path, monkeypatch) -> None
     ]
     _patch_inventory(monkeypatch, manifest)
 
-    result = CliRunner().invoke(cli, ["list", str(tmp_path)])
+    result = CliRunner().invoke(cli, ["list", "--live", str(tmp_path)])
 
     assert result.exit_code == 0
     assert "test_y" in result.output
@@ -268,12 +271,12 @@ def test_list_renders_snapshots_from_the_manifest(tmp_path, monkeypatch) -> None
 def test_stats_shows_a_configured_backend_even_with_no_snapshots(
     tmp_path, monkeypatch
 ) -> None:
-    """An empty-but-resolved backend still appears in `ditto stats`, flagging it to
-    the user as removable or misconfigured."""
+    """An empty-but-resolved backend still appears in `ditto stats --live`, flagging
+    it to the user as removable or misconfigured."""
     manifest = [BackendManifest("redis://h/0", [])]
     _patch_inventory(monkeypatch, manifest)
 
-    result = CliRunner().invoke(cli, ["stats", str(tmp_path)])
+    result = CliRunner().invoke(cli, ["stats", "--live", str(tmp_path)])
 
     assert result.exit_code == 0
     assert "redis://h/0" in result.output
@@ -287,9 +290,9 @@ def test_list_reports_failure_and_exits_one_when_introspection_errors(
     def _boom(path):
         raise cli_mod.IntrospectError("pytest blew up")
 
-    monkeypatch.setattr(cli_mod, "run_introspect", _boom)
+    monkeypatch.setattr("ditto._inventory.run_introspect", _boom)
 
-    result = CliRunner().invoke(cli, ["list", str(tmp_path)])
+    result = CliRunner().invoke(cli, ["list", "--live", str(tmp_path)])
 
     assert result.exit_code == 1
     assert "Introspection failed" in result.output

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from click.testing import CliRunner
 
 from ditto import cli as cli_mod
+from ditto._inventory import InventoryError
 from ditto._manifest import BackendManifest, ManifestEntry
 from ditto.cli import (
     _RECORDER_PALETTE,
@@ -336,3 +337,20 @@ def test_list_reports_failure_and_exits_one_when_introspection_errors(
 
     assert result.exit_code == 1
     assert "Introspection failed" in result.output
+
+
+def test_list_reports_failure_and_exits_one_when_inventory_is_unreadable(
+    tmp_path, monkeypatch
+) -> None:
+    """A filesystem inventory failure is shown without an uncaught traceback."""
+
+    def fail_inventory(path, *, live):
+        raise InventoryError("permission denied")
+
+    monkeypatch.setattr(cli_mod, "build_inventory", fail_inventory)
+
+    result = CliRunner().invoke(cli, ["list", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Inventory failed" in result.output
+    assert "permission denied" in result.output

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -97,6 +97,24 @@ def test_formats_fractional_kilobytes() -> None:
     assert _human_size(1536) == "1.5 KB"
 
 
+def test_human_size_renders_none_as_dash():
+    """An unknown size renders as an em dash, not a crash."""
+    assert _human_size(None) == "—"
+
+
+def test_gather_stats_excludes_unknown_sizes_from_total_but_counts_entries():
+    """Entries with unknown size are counted but contribute no bytes."""
+    entries = [
+        ManifestEntry(storage_key="m.test_a@k.pkl", size_bytes=100, modified=None),
+        ManifestEntry(storage_key="m.test_b@k.pkl", size_bytes=None, modified=None),
+    ]
+
+    stats = gather_stats(entries, {})
+
+    assert stats.total_count == 2
+    assert stats.total_size == 100
+
+
 # ── _build_colour_map ─────────────────────────────────────────────────────────
 
 

--- a/tests/ci/test_cli_commands.py
+++ b/tests/ci/test_cli_commands.py
@@ -341,3 +341,14 @@ def test_list_renders_remote_lock_entry_with_dash(tmp_path) -> None:
     assert result.exit_code == 0
     assert "test_remote" in result.output
     assert "—" in result.output
+    assert "size unknown" in result.output  # the remote-unknown note
+
+
+def test_list_hints_when_no_lockfile(tmp_path) -> None:
+    """With local snapshots but no ditto.lock, list hints that remotes are hidden."""
+    _make_local_snapshot(tmp_path)
+
+    result = CliRunner().invoke(cmd_list, [str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "no ditto.lock found" in result.output

--- a/tests/ci/test_cli_commands.py
+++ b/tests/ci/test_cli_commands.py
@@ -3,13 +3,14 @@ consistency fixes on list/status/clean/recorders."""
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
-from ditto import cli as cli_mod
-from ditto._manifest import ManifestEntry
+from ditto._lockfile import LOCKFILE_VERSION
+from ditto._manifest import BackendManifest, ManifestEntry
 from ditto.cli import (
     RecorderInfo,
     _doctor_checks,
@@ -228,19 +229,15 @@ def test_reports_empty_and_unknown_extension_as_separate_issues() -> None:
 # ── exit code consistency ─────────────────────────────────────────────────────
 
 
-def test_list_exits_one_when_no_snapshots_exist(tmp_path, monkeypatch) -> None:
-    """ditto list exits 1 when the inventory is empty."""
-    monkeypatch.setattr(cli_mod, "run_introspect", lambda path: [])
-
+def test_list_exits_one_when_no_snapshots_exist(tmp_path) -> None:
+    """ditto list exits 1 when the credential-free inventory is empty."""
     result = CliRunner().invoke(cmd_list, [str(tmp_path)])
 
     assert result.exit_code == 1
 
 
-def test_status_exits_one_when_no_snapshots_exist(tmp_path, monkeypatch) -> None:
-    """ditto status exits 1 when the inventory is empty."""
-    monkeypatch.setattr(cli_mod, "run_introspect", lambda path: [])
-
+def test_status_exits_one_when_no_snapshots_exist(tmp_path) -> None:
+    """ditto status exits 1 when the credential-free inventory is empty."""
     result = CliRunner().invoke(cmd_status, [str(tmp_path)])
 
     assert result.exit_code == 1
@@ -284,3 +281,63 @@ def test_prune_without_check_forwards_delete_flag() -> None:
     cmd = run.call_args.args[0]
     assert "--ditto-prune" in cmd
     assert "--ditto-prune-dry-run" not in cmd
+
+
+# ── credential-free default + --live opt-in ───────────────────────────────────
+
+
+def _make_local_snapshot(tmp_path) -> None:
+    ditto = tmp_path / ".ditto"
+    ditto.mkdir()
+    (ditto / "mod.test_a@k.pkl").write_bytes(b"abcd")
+
+
+def test_list_default_does_not_run_introspect(tmp_path) -> None:
+    """The credential-free default `ditto list` never spawns the pytest pass."""
+    _make_local_snapshot(tmp_path)
+    with patch(
+        "ditto._inventory.run_introspect",
+        side_effect=AssertionError("must not introspect"),
+    ):
+        result = CliRunner().invoke(cmd_list, [str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "test_a" in result.output
+
+
+def test_list_live_runs_introspect(tmp_path) -> None:
+    """`ditto list --live` delegates to the introspection pass."""
+    manifest = [
+        BackendManifest(
+            location="redis://h/0",
+            entries=[ManifestEntry("mod.test_live@k.pkl", size_bytes=7, modified=None)],
+        )
+    ]
+    with patch("ditto._inventory.run_introspect", return_value=manifest) as run:
+        result = CliRunner().invoke(cmd_list, [str(tmp_path), "--live"])
+
+    run.assert_called_once()
+    assert result.exit_code == 0
+    assert "test_live" in result.output
+
+
+def test_list_renders_remote_lock_entry_with_dash(tmp_path) -> None:
+    """A remote lock entry shows credential-free with an em-dash size."""
+    lock = {
+        "version": LOCKFILE_VERSION,
+        "targets": {
+            "redis://localhost:6379/0": {
+                "scheme": "redis",
+                "entries": [
+                    {"nodeid": "test_x.py::test_remote", "key": "k", "recorder": "pkl"}
+                ],
+            }
+        },
+    }
+    (tmp_path / "ditto.lock").write_text(json.dumps(lock))
+
+    result = CliRunner().invoke(cmd_list, [str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "test_remote" in result.output
+    assert "—" in result.output

--- a/tests/ci/test_cli_commands.py
+++ b/tests/ci/test_cli_commands.py
@@ -20,6 +20,7 @@ from ditto.cli import (
     cmd_list,
     cmd_prune,
     cmd_recorders,
+    cmd_stats,
     cmd_status,
 )
 
@@ -342,6 +343,29 @@ def test_list_renders_remote_lock_entry_with_dash(tmp_path) -> None:
     assert "test_remote" in result.output
     assert "—" in result.output
     assert "size unknown" in result.output  # the remote-unknown note
+
+
+@pytest.mark.parametrize("command", [cmd_status, cmd_stats])
+def test_remote_only_aggregate_renders_unknown_size_as_dash(command, tmp_path) -> None:
+    """Remote-only aggregate commands never report unknown bytes as zero."""
+    lock = {
+        "version": LOCKFILE_VERSION,
+        "targets": {
+            "redis://localhost:6379/0": {
+                "scheme": "redis",
+                "entries": [
+                    {"nodeid": "test_x.py::test_remote", "key": "k", "recorder": "pkl"}
+                ],
+            }
+        },
+    }
+    (tmp_path / "ditto.lock").write_text(json.dumps(lock))
+
+    result = CliRunner().invoke(command, [str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "—" in result.output
+    assert "0 B" not in result.output
 
 
 def test_list_hints_when_no_lockfile(tmp_path) -> None:

--- a/tests/ci/test_cli_commands.py
+++ b/tests/ci/test_cli_commands.py
@@ -368,6 +368,19 @@ def test_remote_only_aggregate_renders_unknown_size_as_dash(command, tmp_path) -
     assert "0 B" not in result.output
 
 
+@pytest.mark.parametrize("command", [cmd_list, cmd_status, cmd_stats])
+def test_empty_inventory_explains_that_remote_snapshots_need_a_lock(
+    command, tmp_path
+) -> None:
+    """An empty credential-free result directs remote-only users to live mode."""
+    result = CliRunner().invoke(command, [str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "No snapshot files found" in result.output
+    assert "no ditto.lock found" in result.output
+    assert "use --live" in result.output
+
+
 def test_list_hints_when_no_lockfile(tmp_path) -> None:
     """With local snapshots but no ditto.lock, list hints that remotes are hidden."""
     _make_local_snapshot(tmp_path)

--- a/tests/ci/test_inventory.py
+++ b/tests/ci/test_inventory.py
@@ -1,0 +1,141 @@
+from ditto._inventory import (
+    _find_lock,
+    _lock_remote,
+    _walk_local,
+    build_inventory,
+    lock_present,
+)
+from ditto._lockfile import LOCKFILE_VERSION, LockEntry, LockFile, LockTarget
+from ditto.exceptions import DittoWarning
+
+import pytest
+
+
+def _write_snapshot(ditto_dir, name, data=b"xx"):
+    ditto_dir.mkdir(parents=True, exist_ok=True)
+    (ditto_dir / name).write_bytes(data)
+
+
+def test_walk_local_reads_real_sizes_including_orphans(tmp_path):
+    """Local walk reports on-disk files with real sizes, even ones not in a lock."""
+    _write_snapshot(tmp_path / ".ditto", "mod.test_a@k.pkl", b"abcd")
+
+    backends = _walk_local(tmp_path, lock=None, rootdir=None)
+
+    entries = [e for b in backends for e in b.entries]
+    assert len(entries) == 1
+    assert entries[0].storage_key == "mod.test_a@k.pkl"
+    assert entries[0].size_bytes == 4
+    assert entries[0].modified is not None
+
+
+def test_lock_remote_yields_unknown_size_entries(tmp_path):
+    """Remote lock targets become entries with size/mtime None."""
+    lock = LockFile(
+        version=LOCKFILE_VERSION,
+        targets={
+            "redis://localhost:6379/0": LockTarget(
+                scheme="redis",
+                entries=(
+                    LockEntry(nodeid="test_x.py::test_a", key="k", recorder="pkl"),
+                ),
+            )
+        },
+    )
+
+    backends = _lock_remote(lock, tmp_path, rootdir=tmp_path)
+
+    entries = [e for b in backends for e in b.entries]
+    assert len(entries) == 1
+    assert entries[0].size_bytes is None
+    assert entries[0].modified is None
+
+
+def test_lock_remote_scopes_entries_to_path(tmp_path):
+    """Only lock entries whose test file is under PATH are inventoried."""
+    lock = LockFile(
+        version=LOCKFILE_VERSION,
+        targets={
+            "redis://h/0": LockTarget(
+                scheme="redis",
+                entries=(
+                    LockEntry(nodeid="sub/test_in.py::test_a", key="k", recorder="pkl"),
+                    LockEntry(
+                        nodeid="other/test_out.py::test_b", key="k", recorder="pkl"
+                    ),
+                ),
+            )
+        },
+    )
+
+    backends = _lock_remote(lock, tmp_path / "sub", rootdir=tmp_path)
+
+    keys = [e.storage_key for b in backends for e in b.entries]
+    assert any("test_in" in k for k in keys)
+    assert not any("test_out" in k for k in keys)
+
+
+def test_find_lock_searches_ancestors(tmp_path):
+    """_find_lock walks upward from PATH to locate ditto.lock."""
+    (tmp_path / "ditto.lock").write_text("{}")
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+
+    assert _find_lock(nested) == tmp_path / "ditto.lock"
+    assert _find_lock(tmp_path / "a") == tmp_path / "ditto.lock"
+
+
+def test_find_lock_returns_none_when_absent(tmp_path):
+    """_find_lock returns None when no ditto.lock governs PATH."""
+    assert _find_lock(tmp_path) is None
+
+
+def test_build_inventory_live_uses_introspect_only(tmp_path, monkeypatch):
+    """live=True delegates to run_introspect and does not walk the disk."""
+    sentinel = ["SENTINEL"]
+    called = {}
+
+    def fake_introspect(path):
+        called["path"] = path
+        return sentinel
+
+    monkeypatch.setattr("ditto._inventory.run_introspect", fake_introspect)
+
+    result = build_inventory(tmp_path, live=True)
+
+    assert result is sentinel
+    assert called["path"] == tmp_path
+
+
+def test_build_inventory_default_never_introspects(tmp_path, monkeypatch):
+    """Default (credential-free) build never spawns the pytest pass."""
+    _write_snapshot(tmp_path / ".ditto", "mod.test_a@k.pkl")
+
+    def boom(path):
+        raise AssertionError("run_introspect must not be called by default")
+
+    monkeypatch.setattr("ditto._inventory.run_introspect", boom)
+
+    backends = build_inventory(tmp_path, live=False)
+
+    keys = [e.storage_key for b in backends for e in b.entries]
+    assert "mod.test_a@k.pkl" in keys
+
+
+def test_build_inventory_degrades_on_corrupt_lock(tmp_path):
+    """A corrupt ditto.lock warns and degrades to a local-only inventory."""
+    _write_snapshot(tmp_path / ".ditto", "mod.test_a@k.pkl")
+    (tmp_path / "ditto.lock").write_text("{ not json")
+
+    with pytest.warns(DittoWarning):
+        backends = build_inventory(tmp_path, live=False)
+
+    keys = [e.storage_key for b in backends for e in b.entries]
+    assert "mod.test_a@k.pkl" in keys
+
+
+def test_lock_present_reflects_lockfile(tmp_path):
+    """lock_present is True only when a ditto.lock governs PATH."""
+    assert lock_present(tmp_path) is False
+    (tmp_path / "ditto.lock").write_text("{}")
+    assert lock_present(tmp_path) is True

--- a/tests/ci/test_inventory.py
+++ b/tests/ci/test_inventory.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 from ditto._inventory import (
+    InventoryError,
     _find_lock,
     _lock_remote,
     _walk_local,
@@ -34,6 +37,45 @@ def test_walk_local_reads_real_sizes_including_orphans(tmp_path):
     assert entries[0].storage_key == "mod.test_a@k.pkl"
     assert entries[0].size_bytes == 4
     assert entries[0].modified is not None
+
+
+def test_build_inventory_skips_snapshot_that_disappears_before_stat(
+    tmp_path, monkeypatch
+) -> None:
+    """A concurrent snapshot deletion does not fail the remaining inventory."""
+    snapshot = tmp_path / ".ditto" / "mod.test_a@k.pkl"
+    _write_snapshot(snapshot.parent, snapshot.name)
+    original_stat = Path.stat
+
+    def stat_with_disappearing_snapshot(path, *args, **kwargs):
+        if path == snapshot:
+            raise FileNotFoundError(snapshot)
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", stat_with_disappearing_snapshot)
+
+    actual = build_inventory(tmp_path, live=False)
+
+    assert actual == []
+
+
+def test_build_inventory_fails_when_snapshot_metadata_is_unreadable(
+    tmp_path, monkeypatch
+) -> None:
+    """A permission failure is reported instead of yielding a partial inventory."""
+    snapshot = tmp_path / ".ditto" / "mod.test_a@k.pkl"
+    _write_snapshot(snapshot.parent, snapshot.name)
+    original_stat = Path.stat
+
+    def stat_with_unreadable_snapshot(path, *args, **kwargs):
+        if path == snapshot:
+            raise PermissionError("permission denied")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", stat_with_unreadable_snapshot)
+
+    with pytest.raises(InventoryError, match=str(snapshot)):
+        build_inventory(tmp_path, live=False)
 
 
 def test_build_inventory_reads_absolute_file_target_owned_by_scoped_test(

--- a/tests/ci/test_inventory.py
+++ b/tests/ci/test_inventory.py
@@ -5,7 +5,14 @@ from ditto._inventory import (
     build_inventory,
     lock_present,
 )
-from ditto._lockfile import LOCKFILE_VERSION, LockEntry, LockFile, LockTarget
+from ditto._lockfile import (
+    LOCKFILE_VERSION,
+    LockEntry,
+    LockFile,
+    LockTarget,
+    storage_key,
+    write_lockfile,
+)
 from ditto.exceptions import DittoWarning
 
 import pytest
@@ -27,6 +34,65 @@ def test_walk_local_reads_real_sizes_including_orphans(tmp_path):
     assert entries[0].storage_key == "mod.test_a@k.pkl"
     assert entries[0].size_bytes == 4
     assert entries[0].modified is not None
+
+
+def test_build_inventory_reads_absolute_file_target_owned_by_scoped_test(
+    tmp_path,
+) -> None:
+    """A scoped inventory includes an owning test's absolute external target."""
+    project = tmp_path / "project"
+    project.mkdir()
+    target = tmp_path / "external-snapshots"
+    entry = LockEntry(
+        nodeid="test_external.py::test_external",
+        key="value",
+        recorder="pkl",
+    )
+    _write_snapshot(target, storage_key(entry, "file"), b"external")
+    lock = LockFile(
+        version=LOCKFILE_VERSION,
+        targets={
+            target.as_uri(): LockTarget(scheme="file", entries=(entry,)),
+        },
+    )
+    write_lockfile(project / "ditto.lock", lock)
+
+    manifest = build_inventory(project, live=False)
+
+    assert [backend.location for backend in manifest] == [str(target)]
+    assert [item.storage_key for backend in manifest for item in backend.entries] == [
+        storage_key(entry, "file")
+    ]
+
+
+def test_build_inventory_reads_file_target_outside_requested_test_path(
+    tmp_path,
+) -> None:
+    """A test-scoped inventory includes its project-level shared file target."""
+    project = tmp_path / "project"
+    test_path = project / "tests" / "unit"
+    test_path.mkdir(parents=True)
+    target = project / "snapshots"
+    entry = LockEntry(
+        nodeid="tests/unit/test_example.py::test_example",
+        key="value",
+        recorder="pkl",
+    )
+    _write_snapshot(target, storage_key(entry, "file"))
+    lock = LockFile(
+        version=LOCKFILE_VERSION,
+        targets={
+            "snapshots": LockTarget(scheme="file", entries=(entry,)),
+        },
+    )
+    write_lockfile(project / "ditto.lock", lock)
+
+    manifest = build_inventory(test_path, live=False)
+
+    assert [backend.location for backend in manifest] == [str(target)]
+    assert [item.storage_key for backend in manifest for item in backend.entries] == [
+        storage_key(entry, "file")
+    ]
 
 
 def test_lock_remote_yields_unknown_size_entries(tmp_path):


### PR DESCRIPTION
## Phase 4: lock-file-first CLI inventory

**Full design:** #80 · **Closes #77.** Builds on Phases 1–3 (`ditto.lock`, `_reconcile`/`_lockfile`, target schemes), all on `main`.

Makes the read-only inventory commands (`list`/`status`/`stats`/`lint`) **credential-free by default** and turns the live `pytest --setup-only` introspection pass into an opt-in `--live` flag.

### The problem (#77)
These commands unconditionally spawned an internal `pytest --setup-only --ditto-introspect` pass just to enumerate snapshots — importing test modules, paying full pytest startup even for local-only projects, and requiring live credentials merely to render a remote inventory.

### What shipped
- **`src/ditto/_inventory.py` (new):** `build_inventory(path, *, live)` assembles the existing `Manifest` from the cheapest credential-free source per target:
  - **local `file://` targets → the filesystem** (real size + mtime, *including on-disk orphans*), instantly, no pytest, no credentials;
  - **remote targets → the committed `ditto.lock`** (declared entries, size/mtime unknown), scoped to entries under `PATH` by nodeid;
  - **`--live` → today's introspection pass** (authoritative physical state for every target). `run_introspect` is now fully encapsulated behind this module — `cli.py` never calls it directly.
  - A missing lock is a silent local-only inventory; a **corrupt** lock warns (`DittoWarning`) and degrades to local-only rather than failing a read-only command.
- **`ManifestEntry.size_bytes: int → int | None`** to represent "unknown without `--live`", rippling to `_human_size` (`—`) and `gather_stats` (excluded from totals). `lint`'s empty-file check naturally skips unknown sizes.
- **`--live` flag** on all four commands, plus muted notes: `remote: N snapshots, size unknown (use --live)` and a `no ditto.lock found …` hint.
- **Comprehensive docs:** a new [The Lock File](docs/src/guides/lock-file.md) guide (the whole produce/verify/prune/update model + the declared-vs-physical inventory trade-off, with a mermaid routing diagram), a new `ditto verify` page (closing the Phase 2 doc gap), the four inventory pages updated, the `cli/index.md` "remote backends" section rewritten, and nav entries.

### Tests
- Full `tests/ci` green on **py312 and py313** (338 passed, 2 skipped, 2 xfailed each); ruff + basedpyright clean; `zensical` docs build "No issues found".
- New `tests/ci/test_inventory.py` (walk/lock-remote/find-lock/build-inventory routing + corrupt-lock degrade) and CLI integration tests (default never introspects; `--live` does; remote renders `—`). The five existing tests coupled to the old "always introspect" behaviour were migrated to the credential-free default (and the live ones re-pointed to `--live`), not weakened.

### Note
Non-breaking: pre-lock local projects keep working (faster, no pytest); `--live` reproduces today's behaviour exactly.